### PR TITLE
Add rem-scaled components and gallery zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ cargo run --example gallery
 
 The single `gallery` example groups components under Actions, Forms, Navigation, Overlays and Display. Choose a component in the sidebar to inspect and interact with it. Use Up/Down, j/k or Home/End to navigate the sidebar, and Tab to enter the controls. The top Menu reloads the system theme, previews dark or light colors, and exits the gallery.
 
+Use the top-bar − / + controls to test interface zoom from 50% to 200% in 25% steps. Click the percentage to reset to 100%, or use Cmd/Ctrl + `+`, `-`, and `0`. Zoom updates the window's rem size, including list measurements, and persists while switching components and themes in the same window.
+
+UI typography, spacing, icon sizes and control dimensions use rem units and follow `Window::rem_size()`. Pixel-only base APIs (scrollbars, rich-text headings, resizable panels and virtual-list measurements) resolve rem dimensions with the current window. `scrollbar`, `markdown`, `html` and `text_view_style` therefore take `window: &Window` before `cx`. Physical borders, native window bounds, test pointer coordinates and the base theme's nominal typography snapshot remain pixel-based.
+
 ## Themes
 
 `gpui_omarchy::init(cx)` initializes base and first reads:
@@ -74,7 +78,9 @@ Wrap a window or form in `focus_scope("app")` to enable Tab and Shift+Tab traver
 
 `toggle_group(id, cx)` composes independent `toggle` children for multiple-choice filters. Add icons explicitly through child elements.
 
-`button_group(...)` represents a single-choice setting; `tab_list(...)` switches between content pages. Both accept `ChoiceItem` options, the selected index and a callback, returning base RadioGroup and Tabs respectively. Each group has one Tab stop. Left/Right or h/l moves the cursor, and Enter or Space confirms. Use `tabs` and `tab` for custom compositions.
+`button_group(...)` represents a single-choice setting with equal-width segments; `tab_list(...)` switches between content pages in a segmented strip. Both accept `ChoiceItem` options, the selected index and a callback, returning base RadioGroup and Tabs respectively. `tab_list` also takes `show_shortcuts: bool` after the selected index: use `false` for labels only, or `true` for automatic one-based number hints (applications own key bindings). Each group has one Tab stop. Left/Right or h/l moves the cursor, and Enter or Space confirms. Use `tabs` and `tab` for custom compositions.
+
+`input(...)` returns an `Input` supporting `.prefix(element)` and `.suffix(element)` for text, icons or custom content within the input border. Both slots are empty by default and do not change the editable value.
 
 `with_tooltip(control, "Description")` preserves the control's type and adds a tooltip after 400 ms of hovering. `tooltip(text, cx)` returns a customizable tooltip surface. Icon buttons still need explicit accessible names.
 
@@ -89,11 +95,11 @@ Wrap a window or form in `focus_scope("app")` to enable Tab and Shift+Tab traver
 
 `calendar(id, &state, cx)` uses base CalendarState, with month/year navigation, single-date or range selection and disabled-date matchers. `separator` and `vertical_separator` provide horizontal and vertical dividers.
 
-`scrollbar(id, axis, &handle, cx)` returns a themed base Scrollbar. Share its handle with the scrollable content and render it last inside the same relative container. Vertical, horizontal and both-axis configurations are supported.
+`scrollbar(id, axis, &handle, window, cx)` returns a themed base Scrollbar. Share its handle with the scrollable content and render it last inside the same relative container. Vertical, horizontal and both-axis configurations are supported.
 
 `virtual_list(view, id, sizes, render, cx)` returns a base VirtualList that builds only the visible range. Each height in `sizes` must match the corresponding rendered row. Use `.track_scroll(&handle)` to preserve position or navigate to an item. The gallery displays 1,000 activity records with varying heights.
 
-`markdown(id, source, cx)` and `html(id, source, cx)` return base TextView elements with selectable text, links and themed document typography. State-backed TextViews can use `text_view_style(cx)`. Selection uses the application's root TextSelectionLayer.
+`markdown(id, source, window, cx)` and `html(id, source, window, cx)` return base TextView elements with selectable text, links and themed document typography. State-backed TextViews can use `text_view_style(window, cx)`. Selection uses the application's root TextSelectionLayer.
 
 `tree(&state, cx)` uses base TreeState. `resizable(id, axis, cx)` returns a base split container, with dragging and size constraints handled by base. `nav_stack(&state, cx)` preserves base push, pop and forward navigation state.
 

--- a/examples/gallery/app.rs
+++ b/examples/gallery/app.rs
@@ -1,7 +1,10 @@
 use gpui_kit::base::CheckboxState;
+#[cfg(any(test, not(target_family = "wasm")))]
+use gpui_kit::px;
+use gpui_kit::rems;
 use gpui_kit::{
     App, ClickEvent, Context, Entity, FocusHandle, FontWeight, KeyDownEvent, Window, WindowOptions,
-    div, prelude::*, px, size,
+    div, prelude::*, size,
 };
 #[cfg(not(target_family = "wasm"))]
 use gpui_kit::{Bounds, WindowBounds};
@@ -146,6 +149,7 @@ fn description(page: &str) -> &'static str {
 }
 
 struct Gallery {
+    zoom_base_rem: gpui_kit::Pixels,
     workspace_name: Entity<gpui_kit::base::input::InputState>,
     workspace_draft: Entity<gpui_kit::base::input::InputState>,
     saved_workspace: String,
@@ -191,6 +195,7 @@ struct Gallery {
     activity_scroll: gpui_kit::base::VirtualListScrollHandle,
     timeline_scroll: gpui_kit::ScrollHandle,
     activity_sizes: std::rc::Rc<Vec<gpui_kit::Size<gpui_kit::Pixels>>>,
+    activity_rem_size: gpui_kit::Pixels,
     activity_rendered: usize,
     pressed: bool,
     article_filters: [bool; 3],
@@ -207,6 +212,62 @@ struct Gallery {
 }
 
 impl Gallery {
+    fn zoom_percent(&self, window: &Window) -> u16 {
+        (f32::from(window.rem_size()) / f32::from(self.zoom_base_rem) * 100.).round() as u16
+    }
+
+    fn set_zoom(&mut self, percent: u16, window: &mut Window, cx: &mut Context<Self>) {
+        let rem_size = self.zoom_base_rem * (percent.clamp(50, 200) as f32 / 100.);
+        if window.rem_size() == rem_size {
+            return;
+        }
+        window.set_rem_size(rem_size);
+        self.navigation_list.remeasure();
+        window.refresh();
+        cx.notify();
+    }
+
+    fn render_zoom_controls(&self, window: &Window, cx: &Context<Self>) -> gpui_kit::Div {
+        let percent = self.zoom_percent(window);
+        div()
+            .flex()
+            .items_center()
+            .gap_1()
+            .child(with_tooltip(
+                button("zoom-out", "−", ButtonVariant::Secondary, cx)
+                    .debug_selector(|| "zoom-out".into())
+                    .accessibility_label("Zoom out")
+                    .disabled(percent <= 50)
+                    .on_click(cx.listener(|this, _, window, cx| {
+                        this.set_zoom(this.zoom_percent(window).saturating_sub(25), window, cx);
+                    })),
+                "Zoom out (Cmd/Ctrl −)",
+            ))
+            .child(with_tooltip(
+                button(
+                    "zoom-reset",
+                    format!("{percent}%"),
+                    ButtonVariant::Secondary,
+                    cx,
+                )
+                .debug_selector(|| "zoom-reset".into())
+                .accessibility_label(format!("Zoom {percent}%, reset to 100%"))
+                .min_w(rems(3.5))
+                .on_click(cx.listener(|this, _, window, cx| this.set_zoom(100, window, cx))),
+                "Reset zoom (Cmd/Ctrl 0)",
+            ))
+            .child(with_tooltip(
+                button("zoom-in", "+", ButtonVariant::Secondary, cx)
+                    .debug_selector(|| "zoom-in".into())
+                    .accessibility_label("Zoom in")
+                    .disabled(percent >= 200)
+                    .on_click(cx.listener(|this, _, window, cx| {
+                        this.set_zoom(this.zoom_percent(window).saturating_add(25), window, cx);
+                    })),
+                "Zoom in (Cmd/Ctrl +)",
+            ))
+    }
+
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let number =
             cx.new(|cx| gpui_kit::base::input::InputState::new(window, cx).default_value("1"));
@@ -325,7 +386,7 @@ impl Gallery {
         cx.observe(&date_picker_state, |_, _, cx| cx.notify())
             .detach();
         let dock_state = cx.new(|cx| dock_area("gallery-workspace", window, cx));
-        let layout = demo_dock_layout(cx);
+        let layout = demo_dock_layout(window, cx);
         dock_state.update(cx, |state, cx| state.set_center(layout, window, cx));
         Self {
             dock_state,
@@ -342,6 +403,7 @@ impl Gallery {
             workspace_name,
             workspace_draft,
             saved_workspace: "Personal workspace".into(),
+            zoom_base_rem: window.rem_size(),
             theme_mode: 0,
             toolbar_position: 0,
             modal_open: false,
@@ -356,7 +418,7 @@ impl Gallery {
             navigation_list: gpui_kit::ListState::new(
                 GROUPS.len() + components().count(),
                 gpui_kit::ListAlignment::Top,
-                px(100.),
+                rems(6.25).to_pixels(window.rem_size()),
             ),
             navigation_rows: GROUPS
                 .iter()
@@ -393,11 +455,8 @@ impl Gallery {
             sheet_trigger: cx.focus_handle(),
             activity_scroll: gpui_kit::base::VirtualListScrollHandle::new(),
             timeline_scroll: gpui_kit::ScrollHandle::new(),
-            activity_sizes: std::rc::Rc::new(
-                (0..1000)
-                    .map(|index| size(px(400.), px(if index % 5 == 0 { 44. } else { 28. })))
-                    .collect(),
-            ),
+            activity_rem_size: window.rem_size(),
+            activity_sizes: activity_sizes(window),
             activity_rendered: 0,
             pressed: false,
             article_filters: [true, true, false],
@@ -452,12 +511,12 @@ impl Gallery {
         div()
             .flex()
             .flex_col()
-            .gap(px(18.))
+            .gap(rems(1.125))
             .child(
                 div()
                     .flex()
                     .flex_col()
-                    .gap(px(6.))
+                    .gap(rems(0.375))
                     .child(dialog_title("Workspace settings", cx))
                     .child(dialog_description(
                         "Give this workspace a name you can recognize.",
@@ -468,7 +527,7 @@ impl Gallery {
                 div()
                     .flex()
                     .flex_col()
-                    .gap(px(6.))
+                    .gap(rems(0.375))
                     .child("Name")
                     .child(input(
                         if modal { "modal-name" } else { "specimen-name" },
@@ -478,7 +537,7 @@ impl Gallery {
                     ))
                     .child(
                         div()
-                            .text_size(px(11.))
+                            .text_size(rems(0.6875))
                             .text_color(t.secondary)
                             .child(if valid {
                                 "Shown in the workspace switcher."
@@ -492,8 +551,8 @@ impl Gallery {
                 div()
                     .flex()
                     .items_center()
-                    .gap(px(8.))
-                    .py(px(8.))
+                    .gap(rems(0.5))
+                    .py(rems(0.5))
                     .child(icon(IconName::Settings).text_color(t.secondary))
                     .child(
                         div()
@@ -506,7 +565,7 @@ impl Gallery {
                 div()
                     .flex()
                     .justify_end()
-                    .gap(px(8.))
+                    .gap(rems(0.5))
                     .child(
                         dialog_button(
                             if modal {
@@ -567,12 +626,12 @@ impl Gallery {
 
     fn reset_form(&self, modal: bool, cx: &mut Context<Self>) -> gpui_kit::Div {
         let t = cx.omarchy();
-        div().flex().flex_col().gap(px(18.))
-            .child(div().flex().items_center().gap(px(10.))
-                .child(icon(IconName::TriangleAlert).size(px(20.)).text_color(t.danger))
+        div().flex().flex_col().gap(rems(1.125))
+            .child(div().flex().items_center().gap(rems(0.625))
+                .child(icon(IconName::TriangleAlert).size(rems(1.25)).text_color(t.danger))
                 .child(dialog_title("Reset workspace settings?", cx)))
             .child(dialog_description(format!("The custom name “{}” will be replaced with “Personal workspace”. Your files will stay in place.", self.saved_workspace), cx))
-            .child(div().flex().justify_end().gap(px(8.))
+            .child(div().flex().justify_end().gap(rems(0.5))
                 .child(dialog_button(if modal { "modal-cancel" } else { "specimen-cancel" }, "Cancel", ButtonVariant::Secondary, cx)
                     .on_click(cx.listener(move |this, _, window, cx| {
                         if modal { window.dispatch_action(Box::new(gpui_kit::base::actions::Cancel), cx); }
@@ -633,8 +692,8 @@ impl Gallery {
                     .flex()
                     .flex_wrap()
                     .justify_between()
-                    .gap(px(8.))
-                    .py(px(10.))
+                    .gap(rems(0.5))
+                    .py(rems(0.625))
                     .border_b_1()
                     .border_color(t.divider())
                     .child(title)
@@ -682,17 +741,22 @@ impl Gallery {
                     .flex()
                     .flex_wrap()
                     .items_start()
-                    .gap(px(24.))
-                    .child(div().w(px(420.)).max_w(gpui_kit::relative(1.)).child(form))
+                    .gap(rems(1.5))
                     .child(
                         div()
-                            .w(px(220.))
+                            .w(rems(26.25))
+                            .max_w(gpui_kit::relative(1.))
+                            .child(form),
+                    )
+                    .child(
+                        div()
+                            .w(rems(13.75))
                             .flex()
                             .flex_col()
-                            .gap(px(18.))
+                            .gap(rems(1.125))
                             .child(
                                 div()
-                                    .text_size(px(13.))
+                                    .text_size(rems(0.8125))
                                     .font_weight(FontWeight::BOLD)
                                     .child("Preferences"),
                             )
@@ -724,7 +788,7 @@ impl Gallery {
                             .child(separator(cx))
                             .child(
                                 div()
-                                    .text_size(px(13.))
+                                    .text_size(rems(0.8125))
                                     .font_weight(FontWeight::BOLD)
                                     .child("Theme"),
                             )
@@ -736,15 +800,15 @@ impl Gallery {
                             ),
                     ),
             )
-            .child(div().mt(px(18.)).w_full().child(separator(cx)))
+            .child(div().mt(rems(1.125)).w_full().child(separator(cx)))
             .child(
                 div()
-                    .text_size(px(13.))
+                    .text_size(rems(0.8125))
                     .font_weight(FontWeight::BOLD)
                     .child("Explore components"),
             )
             .child(
-                div().flex().flex_wrap().gap(px(8.)).children(
+                div().flex().flex_wrap().gap(rems(0.5)).children(
                     [
                         ("button", "Buttons"),
                         ("input", "Text fields"),
@@ -779,13 +843,13 @@ impl Gallery {
         content = content
             .child(
                 div()
-                    .w(px(360.))
+                    .w(rems(22.5))
                     .max_w(gpui_kit::relative(1.))
-                    .p(px(14.))
+                    .p(rems(0.875))
                     .bg(t.normal_fill())
                     .flex()
                     .flex_col()
-                    .gap(px(8.))
+                    .gap(rems(0.5))
                     .child(self.saved_workspace.clone())
                     .child("Documents")
                     .child("Projects")
@@ -801,7 +865,7 @@ impl Gallery {
                     ButtonVariant::Secondary,
                     cx,
                 )
-                .child(icon(IconName::ChevronDown).size(px(14.))),
+                .child(icon(IconName::ChevronDown).size(rems(0.875))),
                 move |_, _, cx| {
                     let checked = target.read(cx).checked;
                     let enabled = target.read(cx).enabled;
@@ -810,7 +874,7 @@ impl Gallery {
                     div()
                         .flex()
                         .flex_col()
-                        .gap(px(14.))
+                        .gap(rems(0.875))
                         .child(div().font_weight(FontWeight::BOLD).child("Display options"))
                         .child(
                             checkbox(
@@ -864,19 +928,19 @@ impl Gallery {
         content = content
             .child(
                 div()
-                    .w(px(360.))
+                    .w(rems(22.5))
                     .max_w(gpui_kit::relative(1.))
-                    .p(px(14.))
+                    .p(rems(0.875))
                     .bg(t.normal_fill())
                     .flex()
                     .items_center()
-                    .gap(px(14.))
+                    .gap(rems(0.875))
                     .child(
                         div()
                             .flex_1()
                             .flex()
                             .flex_col()
-                            .gap(px(6.))
+                            .gap(rems(0.375))
                             .child(self.saved_workspace.clone())
                             .child(div().text_color(t.secondary).child(if self.pressed {
                                 "In favorites"
@@ -901,7 +965,7 @@ impl Gallery {
                     .text_color(t.secondary)
                     .child("Hover the star for its action. Tab and Return also activate it."),
             )
-            .child(div().mt(px(14.)).child("Tooltip appearance"))
+            .child(div().mt(rems(0.875)).child("Tooltip appearance"))
             .child(tooltip("Add to favorites", cx));
         content
     }
@@ -1040,7 +1104,7 @@ impl Gallery {
                     .overflow_x_scroll()
                     .child(
                         table("projects", cx)
-                            .min_w(px(640.))
+                            .min_w(rems(40.))
                             .child(gpui_kit::base::TableHeader::new("head").child(heading))
                             .child(gpui_kit::base::TableBody::new("body").children(
                                 records.into_iter().enumerate().map(
@@ -1091,8 +1155,8 @@ impl Gallery {
                     .flex()
                     .flex_wrap()
                     .items_center()
-                    .gap(px(8.))
-                    .child(div().w(px(90.)).text_color(t.secondary).child(label))
+                    .gap(rems(0.5))
+                    .child(div().w(rems(5.625)).text_color(t.secondary).child(label))
                     .child(button(key, "Apply", variant, cx).on_click(cx.listener(
                         |this, _, _, cx| {
                             this.count += 1;
@@ -1117,11 +1181,11 @@ impl Gallery {
                     .flex()
                     .flex_wrap()
                     .items_center()
-                    .gap(px(8.))
+                    .gap(rems(0.5))
                     .child(
                         button("icon-action", "", ButtonVariant::Outline, cx)
                             .accessibility_label("Add workspace")
-                            .child(icon(IconName::Plus).size(px(14.)))
+                            .child(icon(IconName::Plus).size(rems(0.875)))
                             .child("Add workspace")
                             .on_click(cx.listener(|this, _, _, cx| {
                                 this.count += 1;
@@ -1131,7 +1195,7 @@ impl Gallery {
                     .child(with_tooltip(
                         button("icon-only", "", ButtonVariant::Outline, cx)
                             .accessibility_label("Add workspace")
-                            .child(icon(IconName::Plus).size(px(14.)))
+                            .child(icon(IconName::Plus).size(rems(0.875)))
                             .on_click(cx.listener(|this, _, _, cx| {
                                 this.count += 1;
                                 cx.notify();
@@ -1141,7 +1205,7 @@ impl Gallery {
                     .child(
                         button("icon-disabled", "", ButtonVariant::Outline, cx)
                             .accessibility_label("Add workspace unavailable")
-                            .child(icon(IconName::Plus).size(px(14.)))
+                            .child(icon(IconName::Plus).size(rems(0.875)))
                             .disabled(true),
                     )
                     .child(
@@ -1176,6 +1240,7 @@ impl Gallery {
                 .map(|&label| ChoiceItem::new(label, label))
                 .collect(),
             Some(self.tab),
+            false,
             move |index, _, cx| {
                 target.update(cx, |this, cx| {
                     this.tab = index;
@@ -1190,10 +1255,10 @@ impl Gallery {
             .role(gpui_kit::Role::TabPanel)
             .flex()
             .flex_col()
-            .gap(px(14.))
-            .p(px(14.))
+            .gap(rems(0.875))
+            .p(rems(0.875))
             .w_full()
-            .min_h(px(240.))
+            .min_h(rems(15.))
             .bg(t.normal_fill());
         match self.tab {
             0 => {
@@ -1217,10 +1282,10 @@ impl Gallery {
                         div()
                             .flex()
                             .justify_between()
-                            .gap(px(14.))
+                            .gap(rems(0.875))
                             .border_b_1()
                             .border_color(t.divider())
-                            .pb(px(10.))
+                            .pb(rems(0.625))
                             .child(name)
                             .child(div().text_color(t.secondary).child(detail)),
                     );
@@ -1247,10 +1312,10 @@ impl Gallery {
                         div()
                             .flex()
                             .justify_between()
-                            .gap(px(14.))
+                            .gap(rems(0.875))
                             .border_b_1()
                             .border_color(t.divider())
-                            .pb(px(10.))
+                            .pb(rems(0.625))
                             .child(event)
                             .child(div().text_color(t.secondary).child(time)),
                     );
@@ -1261,7 +1326,7 @@ impl Gallery {
                     .child("Workspace name")
                     .child(
                         input("tab-workspace-name", &self.workspace_name, window, cx)
-                            .max_w(px(360.)),
+                            .max_w(rems(22.5)),
                     )
                     .child(
                         switch("tab-sync", "Sync workspace", self.enabled, cx)
@@ -1284,58 +1349,66 @@ impl Gallery {
     fn render_resizable_example(
         &mut self,
         mut content: gpui_kit::Div,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> gpui_kit::Div {
         let t = cx.omarchy().clone();
-        content = content.child("Horizontal").child(div().w_full().h(px(300.)).border_1().border_color(t.border)
+        content = content.child("Horizontal").child(div().w_full().h(rems(18.75)).border_1().border_color(t.border)
                     .child(resizable("workspace-panes", gpui_kit::Axis::Horizontal, cx)
-                        .child(resizable_panel().size(px(220.)).size_range(px(140.)..px(420.))
-                            .child(div().size_full().p(px(14.)).flex().flex_col().gap(px(10.))
+                        .child(resizable_panel().size(rems(13.75).to_pixels(window.rem_size())).size_range(rems(8.75).to_pixels(window.rem_size())..rems(26.25).to_pixels(window.rem_size()))
+                            .child(div().size_full().p(rems(0.875)).flex().flex_col().gap(rems(0.625))
                                 .child("Documents").child("Project brief.md").child("Meeting notes.md")))
-                        .child(resizable_panel().size_range(px(180.)..px(1600.))
-                            .child(div().size_full().p(px(14.)).flex().flex_col().gap(px(14.))
+                        .child(resizable_panel().size_range(rems(11.25).to_pixels(window.rem_size())..rems(100.0).to_pixels(window.rem_size()))
+                            .child(div().size_full().p(rems(0.875)).flex().flex_col().gap(rems(0.875))
                                 .child(div().font_weight(FontWeight::BOLD).child("Project brief"))
                                 .child("A focused desktop workspace for files, notes and project activity.")
                                 .child(div().text_color(t.secondary).child("Drag the divider to give this preview more room."))))));
         content = content.child("Vertical").child(
             div()
                 .w_full()
-                .h(px(240.))
+                .h(rems(15.))
                 .border_1()
                 .border_color(t.border)
                 .child(
                     resizable("preview-console", gpui_kit::Axis::Vertical, cx)
                         .child(
                             resizable_panel()
-                                .size(px(140.))
-                                .size_range(px(80.)..px(180.))
+                                .size(rems(8.75).to_pixels(window.rem_size()))
+                                .size_range(
+                                    rems(5.0).to_pixels(window.rem_size())
+                                        ..rems(11.25).to_pixels(window.rem_size()),
+                                )
                                 .child(
                                     div()
                                         .size_full()
-                                        .p(px(14.))
+                                        .p(rems(0.875))
                                         .flex()
                                         .flex_col()
-                                        .gap(px(10.))
+                                        .gap(rems(0.625))
                                         .child("Preview")
                                         .child("The workspace is ready for review."),
                                 ),
                         )
                         .child(
-                            resizable_panel().size_range(px(60.)..px(160.)).child(
-                                div()
-                                    .size_full()
-                                    .p(px(14.))
-                                    .flex()
-                                    .flex_col()
-                                    .gap(px(10.))
-                                    .child("Activity")
-                                    .child(
-                                        div()
-                                            .text_color(t.secondary)
-                                            .child("All changes saved · No pending tasks"),
-                                    ),
-                            ),
+                            resizable_panel()
+                                .size_range(
+                                    rems(3.75).to_pixels(window.rem_size())
+                                        ..rems(10.0).to_pixels(window.rem_size()),
+                                )
+                                .child(
+                                    div()
+                                        .size_full()
+                                        .p(rems(0.875))
+                                        .flex()
+                                        .flex_col()
+                                        .gap(rems(0.625))
+                                        .child("Activity")
+                                        .child(
+                                            div()
+                                                .text_color(t.secondary)
+                                                .child("All changes saved · No pending tasks"),
+                                        ),
+                                ),
                         ),
                 ),
         );
@@ -1362,8 +1435,8 @@ impl Gallery {
                 div()
                     .flex()
                     .items_center()
-                    .gap(px(10.))
-                    .pb(px(10.))
+                    .gap(rems(0.625))
+                    .pb(rems(0.625))
                     .border_b_1()
                     .border_color(t.divider())
                     .child(avatar(initials, cx).when(initials == "HL", |avatar| {
@@ -1379,19 +1452,19 @@ impl Gallery {
                 div()
                     .flex()
                     .items_center()
-                    .gap(px(14.))
+                    .gap(rems(0.875))
                     .child(
                         avatar("HL", cx)
                             .image(avatar_image(gallery_avatar()))
-                            .size(px(24.))
-                            .text_size(px(10.)),
+                            .size(rems(1.5))
+                            .text_size(rems(0.625)),
                     )
                     .child(avatar("HL", cx).image(avatar_image(gallery_avatar())))
                     .child(
                         avatar("HL", cx)
                             .image(avatar_image(gallery_avatar()))
-                            .size(px(48.))
-                            .text_size(px(16.)),
+                            .size(rems(3.))
+                            .text_size(rems(1.)),
                     ),
             );
         content
@@ -1408,7 +1481,7 @@ impl Gallery {
                         div()
                             .flex()
                             .items_center()
-                            .gap(px(8.))
+                            .gap(rems(0.5))
                             .child(
                                 button("nav-back", "Back", ButtonVariant::Outline, cx)
                                     .debug_selector(|| "nav-back".into())
@@ -1437,7 +1510,7 @@ impl Gallery {
                                 },
                             )),
                     )
-                    .child(nav_stack(&self.nav_state, cx).h(px(340.)))
+                    .child(nav_stack(&self.nav_state, cx).h(rems(21.25)))
                     .child(div().text_color(t.secondary).child(
                         "Try it: open Website refresh, open its task, edit the note, then go Back and Forward. Your note stays on the task page.",
                     ));
@@ -1459,7 +1532,7 @@ impl Gallery {
                 div()
                     .flex()
                     .items_center()
-                    .gap(px(8.))
+                    .gap(rems(0.5))
                     .child(
                         button("advance", "Advance 10%", ButtonVariant::Primary, cx).on_click(
                             cx.listener(|this, _, _, cx| {
@@ -1539,7 +1612,7 @@ impl Gallery {
             div()
                 .flex()
                 .items_center()
-                .gap(px(8.))
+                .gap(rems(0.5))
                 .child(keycap("Tab", cx))
                 .child("Next control")
                 .child(keycap("Return", cx))
@@ -1559,12 +1632,17 @@ impl Gallery {
             .child("Appearance")
             .child(separator(cx))
             .child("Keyboard")
-            .child(div().mt(px(14.)).text_color(t.secondary).child("Vertical"))
+            .child(
+                div()
+                    .mt(rems(0.875))
+                    .text_color(t.secondary)
+                    .child("Vertical"),
+            )
             .child(
                 div()
                     .flex()
                     .items_center()
-                    .gap(px(10.))
+                    .gap(rems(0.625))
                     .child(
                         button("separator-add", "Add", ButtonVariant::Secondary, cx).on_click(
                             cx.listener(|this, _, _, cx| {
@@ -1660,8 +1738,8 @@ impl Gallery {
         let color = self.color_state.read(cx).value().unwrap_or(t.accent);
         content = content.child("Project label color")
                     .child(color_picker("project-color", &self.color_state, window, cx))
-                    .child(div().flex().items_center().gap(px(10.))
-                        .child(div().size(px(20.)).bg(color))
+                    .child(div().flex().items_center().gap(rems(0.625))
+                        .child(div().size(rems(1.25)).bg(color))
                         .child("Website refresh"))
                     .child(div().text_color(t.secondary).child("The swatch shows the committed label color. Escape discards an unconfirmed Hex edit."));
         content
@@ -1675,7 +1753,7 @@ impl Gallery {
         let t = cx.omarchy().clone();
         content = content
             .child("Workspace files")
-            .child(tree(&self.tree_state, cx).max_w(px(440.)))
+            .child(tree(&self.tree_state, cx).max_w(rems(27.5)))
             .child(
                 div().text_color(t.secondary).child(
                     self.tree_state
@@ -1702,10 +1780,10 @@ impl Gallery {
         content = content
                     .child(button("reset-dock", "Reset layout", ButtonVariant::Outline, cx)
                         .on_click(cx.listener(|this, _, window, cx| {
-                            let layout = demo_dock_layout(cx);
+                            let layout = demo_dock_layout(window, cx);
                             this.dock_state.update(cx, |state, cx| state.set_center(layout, window, cx));
                         })))
-                    .child(div().w_full().h(px(360.)).child(self.dock_state.clone()))
+                    .child(div().w_full().h(rems(22.5)).child(self.dock_state.clone()))
                     .child(div().text_color(t.secondary).child("Drag tabs to merge or split panes. Drag a divider to resize. Reset layout restores all three panels."));
         content
     }
@@ -1723,14 +1801,14 @@ impl Gallery {
                 div()
                     .flex()
                     .items_center()
-                    .gap(px(8.))
+                    .gap(rems(0.5))
                     .child(avatar("AL", cx))
                     .child("Alex Lee"),
                 |_, _, cx| {
                     div()
                         .flex()
                         .flex_col()
-                        .gap(px(10.))
+                        .gap(rems(0.625))
                         .child(div().font_weight(FontWeight::BOLD).child("Alex Lee"))
                         .child("Design engineer · Workspace owner")
                         .child(
@@ -1769,7 +1847,7 @@ impl Gallery {
                 div()
                     .flex()
                     .items_center()
-                    .gap(px(8.))
+                    .gap(rems(0.5))
                     .child(
                         button("reset-otp", "Reset code", ButtonVariant::Outline, cx)
                             .disabled(self.otp_disabled)
@@ -1902,7 +1980,7 @@ impl Gallery {
             }))
             .flex()
             .flex_col()
-            .gap(px(4.));
+            .gap(rems(0.25));
         for (index, label) in ["Compact", "Comfortable", "Spacious"]
             .into_iter()
             .enumerate()
@@ -1927,10 +2005,10 @@ impl Gallery {
                     }))),
             );
         }
-        let row_height = [28., 36., 44.][self.choice];
+        let row_height = [1.75, 2.25, 2.75][self.choice];
         let mut preview = div()
             .w_full()
-            .max_w(px(420.))
+            .max_w(rems(26.25))
             .border_1()
             .border_color(theme.border)
             .flex()
@@ -1946,8 +2024,8 @@ impl Gallery {
             preview = preview.child(
                 div()
                     .debug_selector(move || format!("density-preview-{index}"))
-                    .h(px(row_height))
-                    .px(px(10.))
+                    .h(rems(row_height))
+                    .px(rems(0.625))
                     .flex()
                     .items_center()
                     .justify_between()
@@ -1961,7 +2039,7 @@ impl Gallery {
                 div()
                     .flex()
                     .flex_col()
-                    .gap(px(8.))
+                    .gap(rems(0.5))
                     .child("List density")
                     .child(options),
             )
@@ -1969,7 +2047,7 @@ impl Gallery {
                 div()
                     .flex()
                     .flex_col()
-                    .gap(px(8.))
+                    .gap(rems(0.5))
                     .child("Preview")
                     .child(preview),
             )
@@ -2046,7 +2124,7 @@ impl Gallery {
     ) -> gpui_kit::Div {
         content = content
             .child("Workspace notes")
-            .child(textarea("notes", &self.textarea, window, cx).max_w(px(520.)))
+            .child(textarea("notes", &self.textarea, window, cx).max_w(rems(32.5)))
             .child("Supports multiple lines, selection, clipboard and IME");
         content
     }
@@ -2058,12 +2136,22 @@ impl Gallery {
     ) -> gpui_kit::Div {
         content = content
             .child("Workspace name")
-            .child(input("workspace-name", &self.input, window, cx).max_w(px(380.)))
+            .child(
+                input("workspace-name", &self.input, window, cx)
+                    .prefix(icon(IconName::Settings).size(rems(0.875)))
+                    .max_w(rems(23.75)),
+            )
+            .child("Quantity")
+            .child(
+                input("quantity-with-unit", &self.number, window, cx)
+                    .suffix("shares")
+                    .max_w(rems(23.75)),
+            )
             .child(
                 div()
                     .flex()
                     .items_center()
-                    .gap(px(8.))
+                    .gap(rems(0.5))
                     .child(
                         button("submit-input", "Read value", ButtonVariant::Primary, cx).on_click(
                             cx.listener(|this, _, _, cx| {
@@ -2222,14 +2310,14 @@ impl Gallery {
     fn render_notifications(&self, cx: &mut Context<Self>) -> impl IntoElement + use<> {
         div()
             .absolute()
-            .right(px(14.))
-            .bottom(px(48.))
-            .w(px(320.))
+            .right(rems(0.875))
+            .bottom(rems(3.))
+            .w(rems(20.))
             .id("notification-stack")
             .track_focus(&self.toast_focus)
             .flex()
             .flex_col()
-            .gap(px(8.))
+            .gap(rems(0.5))
             .occlude()
             .on_hover(cx.listener(|this, hovered, _, _| this.toast_hovered = *hovered))
             .children(
@@ -2251,14 +2339,14 @@ impl Gallery {
                                 div()
                                     .flex()
                                     .items_center()
-                                    .gap(px(10.))
+                                    .gap(rems(0.625))
                                     .child(
                                         icon(if id == 1 {
                                             IconName::TriangleAlert
                                         } else {
                                             IconName::Check
                                         })
-                                        .size(px(16.)),
+                                        .size(rems(1.)),
                                     )
                                     .child(div().flex_1().child(message))
                                     .child(
@@ -2268,12 +2356,12 @@ impl Gallery {
                                             ButtonVariant::Secondary,
                                             cx,
                                         )
-                                        .size(px(18.))
-                                        .p(px(0.))
+                                        .size(rems(1.125))
+                                        .p(rems(0.))
                                         .flex_shrink_0()
                                         .debug_selector(|| "dismiss-toast".into())
                                         .accessibility_label("Dismiss notification")
-                                        .child(icon(IconName::Close).size(px(14.)))
+                                        .child(icon(IconName::Close).size(rems(0.875)))
                                         .on_click(
                                             cx.listener(move |this, _, _, cx| {
                                                 this.dismiss_toast_id(id, cx)
@@ -2327,7 +2415,7 @@ impl Gallery {
                 div()
                     .flex()
                     .flex_wrap()
-                    .gap(px(8.))
+                    .gap(rems(0.5))
                     .child(
                         button("show-toast", "Save workspace", ButtonVariant::Outline, cx)
                             .on_click(cx.listener(|this, _, _, cx| {
@@ -2380,7 +2468,7 @@ impl Gallery {
                                 } else {
                                     IconName::ChevronRight
                                 })
-                                .size(px(14.)),
+                                .size(rems(0.875)),
                             )
                             .child("Advanced settings")
                             .on_click(cx.listener(|this, _, _, cx| {
@@ -2392,8 +2480,8 @@ impl Gallery {
                         div()
                             .flex()
                             .flex_col()
-                            .gap(px(14.))
-                            .p(px(14.))
+                            .gap(rems(0.875))
+                            .p(rems(0.875))
                             .bg(t.normal_fill())
                             .child("Workspace synchronization")
                             .child(
@@ -2435,7 +2523,7 @@ impl Gallery {
                 div()
                     .flex()
                     .items_center()
-                    .gap(px(8.))
+                    .gap(rems(0.5))
                     .child(icon(glyph))
                     .child(name),
             );
@@ -2474,7 +2562,7 @@ impl Gallery {
         content = content
             .child(
                 div()
-                    .text_size(px(13.))
+                    .text_size(rems(0.8125))
                     .font_weight(FontWeight::BOLD)
                     .child(if alert {
                         "Destructive confirmation"
@@ -2487,13 +2575,13 @@ impl Gallery {
             } else {
                 "A short task with visible labels and outline actions."
             }))
-            .child(dialog_popup(cx).w(px(460.)).child(specimen))
+            .child(dialog_popup(cx).w(rems(28.75)).child(specimen))
             .child(
                 div()
                     .flex()
                     .items_center()
-                    .gap(px(12.))
-                    .mt(px(6.))
+                    .gap(rems(0.75))
+                    .mt(rems(0.375))
                     .child(
                         dialog_button(
                             "open-modal",
@@ -2538,7 +2626,7 @@ impl Gallery {
                 .id("modal-surface")
                 .occlude()
                 .max_w(gpui_kit::relative(0.9))
-                .child(dialog_popup(cx).w(px(460.)).child(body));
+                .child(dialog_popup(cx).w(rems(28.75)).child(body));
             let close = cx.listener(|this, confirmed: &bool, window, cx| {
                 this.modal_open = false;
                 if *confirmed {
@@ -2611,11 +2699,11 @@ impl Gallery {
         content = content
             .child(
                 div()
-                    .w(px(360.))
+                    .w(rems(22.5))
                     .max_w(gpui_kit::relative(1.))
                     .flex()
                     .flex_col()
-                    .gap(px(8.))
+                    .gap(rems(0.5))
                     .child(if searchable {
                         "Find a workspace"
                     } else {
@@ -2627,16 +2715,16 @@ impl Gallery {
                             .text_color(t.secondary)
                             .child("Archived workspaces cannot be selected."),
                     )
-                    .child(div().mt(px(12.)).child(format!("Selected: {selected}"))),
+                    .child(div().mt(rems(0.75)).child(format!("Selected: {selected}"))),
             )
-            .child(div().mt(px(18.)).w_full().child(separator(cx)))
+            .child(div().mt(rems(1.125)).w_full().child(separator(cx)))
             .child(
                 div()
-                    .w(px(360.))
+                    .w(rems(22.5))
                     .max_w(gpui_kit::relative(1.))
                     .flex()
                     .flex_col()
-                    .gap(px(8.))
+                    .gap(rems(0.5))
                     .child("Managed workspace")
                     .child(disabled)
                     .child(
@@ -2686,13 +2774,18 @@ impl Gallery {
 }
 
 impl Gallery {
-    fn render_text_view(&self, content: gpui_kit::Div, cx: &App) -> gpui_kit::Div {
-        content.child(markdown("project-brief", "## Website refresh\n\nA clearer home for our **project documentation**. Keep navigation simple and preserve the reading experience.\n\n### Before launch\n\n- Review the introduction and installation steps.\n- Verify keyboard navigation in both themes.\n- Publish the release notes.\n\n> Changes should make the next step easier to understand.\n\nRun the gallery locally:\n\n```sh\ncargo run --example gallery\n```\n\nRead the [project source](https://github.com/huacnlee/gpui-omarchy) for usage examples.", cx))
+    fn render_text_view(&self, content: gpui_kit::Div, window: &Window, cx: &App) -> gpui_kit::Div {
+        content.child(markdown("project-brief", "## Website refresh\n\nA clearer home for our **project documentation**. Keep navigation simple and preserve the reading experience.\n\n### Before launch\n\n- Review the introduction and installation steps.\n- Verify keyboard navigation in both themes.\n- Publish the release notes.\n\n> Changes should make the next step easier to understand.\n\nRun the gallery locally:\n\n```sh\ncargo run --example gallery\n```\n\nRead the [project source](https://github.com/huacnlee/gpui-omarchy) for usage examples.", window, cx))
             .child(separator(cx))
-            .child(html("release-summary", "<h3>Release summary</h3><p><strong>Ready for review.</strong> The documentation is complete; launch follows the final keyboard check.</p><p><em>Updated by Alex Lee</em></p>", cx))
+            .child(html("release-summary", "<h3>Release summary</h3><p><strong>Ready for review.</strong> The documentation is complete; launch follows the final keyboard check.</p><p><em>Updated by Alex Lee</em></p>", window, cx))
     }
 
-    fn render_horizontal_scrollbar(&self, content: gpui_kit::Div, cx: &App) -> gpui_kit::Div {
+    fn render_horizontal_scrollbar(
+        &self,
+        content: gpui_kit::Div,
+        window: &Window,
+        cx: &App,
+    ) -> gpui_kit::Div {
         let t = cx.omarchy();
         content
             .child("Project timeline · Scroll horizontally")
@@ -2707,11 +2800,11 @@ impl Gallery {
                         div()
                             .id("timeline-scroll")
                             .w_full()
-                            .h(px(76.))
+                            .h(rems(4.75))
                             .overflow_x_scroll()
                             .track_scroll(&self.timeline_scroll)
                             .child(
-                                div().flex().w(px(1440.)).h(px(64.)).children(
+                                div().flex().w(rems(90.)).h(rems(4.)).children(
                                     [
                                         "Brief",
                                         "Research",
@@ -2726,15 +2819,15 @@ impl Gallery {
                                     .enumerate()
                                     .map(|(index, name)| {
                                         div()
-                                            .w(px(180.))
+                                            .w(rems(11.25))
                                             .flex_shrink_0()
                                             .h_full()
-                                            .p(px(10.))
+                                            .p(rems(0.625))
                                             .border_r_1()
                                             .border_color(t.divider())
                                             .flex()
                                             .flex_col()
-                                            .gap(px(4.))
+                                            .gap(rems(0.25))
                                             .child(name)
                                             .child(
                                                 div()
@@ -2749,6 +2842,7 @@ impl Gallery {
                         "timeline-scrollbar",
                         gpui_kit::base::ScrollbarAxis::Horizontal,
                         &self.timeline_scroll,
+                        window,
                         cx,
                     )),
             )
@@ -2757,10 +2851,15 @@ impl Gallery {
     fn render_activity_list(
         &mut self,
         mut content: gpui_kit::Div,
+        window: &Window,
         cx: &mut Context<Self>,
     ) -> gpui_kit::Div {
+        if self.activity_rem_size != window.rem_size() {
+            self.activity_rem_size = window.rem_size();
+            self.activity_sizes = activity_sizes(window);
+        }
         content = content.child("Sample activity · 1,000 events").child(
-            div().flex().gap(px(8.)).children(
+            div().flex().gap(rems(0.5)).children(
                 [
                     ("activity-first", "First event", 0),
                     ("activity-last", "Last event", 999),
@@ -2790,7 +2889,7 @@ impl Gallery {
                             .debug_selector(move || format!("activity-row-{index}"))
                             .h(this.activity_sizes[index].height)
                             .w_full()
-                            .px(px(10.))
+                            .px(rems(0.625))
                             .flex()
                             .flex_col()
                             .justify_center()
@@ -2810,7 +2909,7 @@ impl Gallery {
         .track_scroll(&self.activity_scroll);
         content.child(div().relative().w_full().border_1().border_color(cx.omarchy().border)
             .debug_selector(|| "activity-viewport".into()).child(list)
-            .child(scrollbar("activity-scrollbar", gpui_kit::base::ScrollbarAxis::Vertical, &self.activity_scroll, cx)))
+            .child(scrollbar("activity-scrollbar", gpui_kit::base::ScrollbarAxis::Vertical, &self.activity_scroll, window, cx)))
             .child(div().text_color(cx.omarchy().secondary).child("Scroll through the log or jump to either end. Longer events keep their full description."))
     }
 }
@@ -2824,7 +2923,7 @@ impl Render for Gallery {
             .flex_col()
             .items_start()
             .w_full()
-            .gap(px(14.))
+            .gap(rems(0.875))
             .min_w_0();
         match self.page {
             "overview" => {
@@ -2960,12 +3059,12 @@ impl Render for Gallery {
                     .child(div().text_color(t.secondary).child("Inspect the project without leaving this page. Close the panel or press Escape to return."));
             }
             "text_view" => {
-                content = self.render_text_view(content, cx);
+                content = self.render_text_view(content, window, cx);
             }
             "virtual_list" | "scrollbar" => {
-                content = self.render_activity_list(content, cx);
+                content = self.render_activity_list(content, window, cx);
                 if self.page == "scrollbar" {
-                    content = self.render_horizontal_scrollbar(content, cx);
+                    content = self.render_horizontal_scrollbar(content, window, cx);
                 }
             }
             "progress" => {
@@ -2973,22 +3072,23 @@ impl Render for Gallery {
             }
             _ => unreachable!(),
         }
-        let sidebar_width = if window.viewport_size().width < px(700.) {
-            148.
-        } else {
-            196.
-        };
+        let sidebar_width =
+            if window.viewport_size().width < rems(43.75).to_pixels(window.rem_size()) {
+                9.25
+            } else {
+                12.25
+            };
         let navigation = div()
             .id("component-sidebar")
             .track_focus(&self.navigation_focus)
-            .w(px(sidebar_width))
+            .w(rems(sidebar_width))
             .h_full()
             .flex_shrink_0()
             .overflow_hidden()
             .border_r_1()
             .border_color(t.divider())
             .bg(t.background)
-            .p(px(8.))
+            .p(rems(0.5))
             .on_key_down(cx.listener(|this, event: &KeyDownEvent, _, cx| {
                 if event.keystroke.modifiers.modified() {
                     return;
@@ -3025,24 +3125,24 @@ impl Render for Gallery {
                             let t = cx.omarchy().clone();
                             if header {
                                 return div()
-                                    .mt(px(if index == 0 { 0. } else { 12. }))
-                                    .mb(px(2.))
-                                    .px(px(8.))
-                                    .py(px(6.))
-                                    .text_size(px(10.))
+                                    .mt(rems(if index == 0 { 0. } else { 0.75 }))
+                                    .mb(rems(0.125))
+                                    .px(rems(0.5))
+                                    .py(rems(0.375))
+                                    .text_size(rems(0.625))
                                     .font_weight(FontWeight::BOLD)
                                     .text_color(t.secondary)
                                     .child(name)
                                     .into_any_element();
                             }
                             div()
-                                .pb(px(2.))
+                                .pb(rems(0.125))
                                 .child(
                                     button(name, display_name(name), ButtonVariant::Secondary, cx)
                                         .w_full()
                                         .justify_start()
-                                        .px(px(8.))
-                                        .py(px(5.))
+                                        .px(rems(0.5))
+                                        .py(rems(0.3125))
                                         .border_color(t.foreground.opacity(0.))
                                         .selected(this.page == name)
                                         .focusable(false)
@@ -3067,6 +3167,21 @@ impl Render for Gallery {
                 .size_full(),
             );
         focus_scope("gallery")
+            .capture_key_down(cx.listener(|this, event: &KeyDownEvent, window, cx| {
+                let modifiers = event.keystroke.modifiers;
+                if !(modifiers.platform || modifiers.control) || modifiers.alt {
+                    return;
+                }
+                let current = this.zoom_percent(window);
+                let next = match event.keystroke.key.as_str() {
+                    "+" | "=" => current.saturating_add(25),
+                    "-" => current.saturating_sub(25),
+                    "0" => 100,
+                    _ => return,
+                };
+                this.set_zoom(next, window, cx);
+                cx.stop_propagation();
+            }))
             .relative()
             .debug_selector(|| "gallery-root".into())
             .size_full()
@@ -3075,21 +3190,21 @@ impl Render for Gallery {
             .bg(t.background)
             .text_color(t.foreground)
             .font_family(t.font.clone())
-            .text_size(px(12.))
+            .text_size(rems(0.75))
             .child(
                 div()
                     .flex()
                     .flex_wrap()
                     .items_center()
                     .justify_between()
-                    .gap(px(8.))
-                    .px(px(14.))
-                    .py(px(10.))
+                    .gap(rems(0.5))
+                    .px(rems(0.875))
+                    .py(rems(0.625))
                     .border_b_1()
                     .border_color(t.divider())
                     .child(
                         div()
-                            .text_size(px(14.))
+                            .text_size(rems(0.875))
                             .font_weight(FontWeight::BOLD)
                             .flex_1()
                             .on_mouse_down(gpui_kit::MouseButton::Left, |_, window, _| {
@@ -3097,6 +3212,7 @@ impl Render for Gallery {
                             })
                             .child("GPUI Omarchy"),
                     )
+                    .child(self.render_zoom_controls(window, cx))
                     .child(
                         menu(
                             "application-menu",
@@ -3108,7 +3224,7 @@ impl Render for Gallery {
                                     cx,
                                 )
                                 .styles(|styles| styles.selected(|style| style.bg(t.border)))
-                                .child(icon(IconName::ChevronDown).size(px(14.))),
+                                .child(icon(IconName::ChevronDown).size(rems(0.875))),
                                 "Appearance and application commands",
                             ),
                             vec![
@@ -3154,21 +3270,21 @@ impl Render for Gallery {
                         .min_w_0()
                         .h_full()
                         .overflow_y_scroll()
-                        .p(px(28.))
+                        .p(rems(1.75))
                         .child(
                             div()
                                 .flex()
                                 .flex_col()
-                                .gap(px(14.))
-                                .max_w(px(760.))
+                                .gap(rems(0.875))
+                                .max_w(rems(47.5))
                                 .child(
                                     div()
-                                        .text_size(px(16.))
+                                        .text_size(rems(1.))
                                         .font_weight(FontWeight::BOLD)
                                         .child(display_name(self.page)),
                                 )
                                 .child(div().text_color(t.secondary).child(description(self.page)))
-                                .child(div().mt(px(14.)).child(content)),
+                                .child(div().mt(rems(0.875)).child(content)),
                         ),
                 ),
             )
@@ -3177,8 +3293,8 @@ impl Render for Gallery {
                     .w_full()
                     .min_w_0()
                     .flex_shrink_0()
-                    .px(px(14.))
-                    .py(px(8.))
+                    .px(rems(0.875))
+                    .py(rems(0.5))
                     .border_t_1()
                     .border_color(t.divider())
                     .text_color(t.secondary)
@@ -3186,20 +3302,20 @@ impl Render for Gallery {
                     .flex_wrap()
                     .items_center()
                     .justify_between()
-                    .gap(px(8.))
+                    .gap(rems(0.5))
                     .child(div().child(
                         "↑↓ / j k  component · Tab / Shift + Tab  focus · Return / Space  activate",
                     ))
                     .child(
-                        div().flex().flex_1().min_w(px(320.)).justify_end().child(
+                        div().flex().flex_1().min_w(rems(20.)).justify_end().child(
                             link(
                                 "repository",
                                 "https://github.com/huacnlee/gpui-omarchy",
                                 "https://github.com/huacnlee/gpui-omarchy",
                                 cx,
                             )
-                            .py(px(0.))
-                            .px(px(0.))
+                            .py(rems(0.))
+                            .px(rems(0.))
                             .flex_shrink_0()
                             .debug_selector(|| "gallery-repository".into())
                             .text_color(t.secondary),
@@ -3216,7 +3332,7 @@ impl Render for Gallery {
     }
 }
 
-fn demo_dock_layout(cx: &mut App) -> gpui_kit::base::dock::DockLayout {
+fn demo_dock_layout(window: &Window, cx: &mut App) -> gpui_kit::base::dock::DockLayout {
     use gpui_kit::base::dock::DockLayout;
     let files = cx.new(|cx| DemoDockPanel {
         title: "Files",
@@ -3231,7 +3347,10 @@ fn demo_dock_layout(cx: &mut App) -> gpui_kit::base::dock::DockLayout {
         focus: cx.focus_handle(),
     });
     DockLayout::h_split()
-        .child(DockLayout::tabs().panel(files).panel(notes), Some(px(280.)))
+        .child(
+            DockLayout::tabs().panel(files).panel(notes),
+            Some(rems(17.5).to_pixels(window.rem_size())),
+        )
         .child(DockLayout::tabs().panel(preview), None)
 }
 
@@ -3254,10 +3373,10 @@ impl gpui_kit::Render for DemoDockPanel {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         div()
             .size_full()
-            .p(px(14.))
+            .p(rems(0.875))
             .flex()
             .flex_col()
-            .gap(px(10.))
+            .gap(rems(0.625))
             .track_focus(&self.focus)
             .child(div().font_weight(FontWeight::BOLD).child(self.title))
             .children(
@@ -3316,13 +3435,13 @@ impl gpui_kit::Render for NavigationPage {
             .id("navigation-page")
             .size_full()
             .overflow_y_scroll()
-            .p(px(18.))
+            .p(rems(1.125))
             .flex()
             .flex_col()
-            .gap(px(14.))
+            .gap(rems(0.875))
             .child(
                 div()
-                    .text_size(px(16.))
+                    .text_size(rems(1.))
                     .font_weight(FontWeight::BOLD)
                     .child(title),
             )
@@ -3341,13 +3460,13 @@ impl gpui_kit::Render for NavigationPage {
                     .debug_selector(|| "nav-open".to_string())
                     .w_full()
                     .justify_between()
-                    .py(px(12.))
+                    .py(rems(0.75))
                     .child(
                         div()
                             .flex()
                             .flex_col()
                             .items_start()
-                            .gap(px(4.))
+                            .gap(rems(0.25))
                             .child(name)
                             .child(div().text_color(t.secondary).child(detail)),
                     )
@@ -3469,6 +3588,19 @@ fn change<T>(
     listener: impl Fn(&T, &mut Window, &mut App) + 'static,
 ) -> impl Fn(T, &ClickEvent, &mut Window, &mut App) {
     move |value, _, window, cx| listener(&value, window, cx)
+}
+
+fn activity_sizes(window: &Window) -> std::rc::Rc<Vec<gpui_kit::Size<gpui_kit::Pixels>>> {
+    std::rc::Rc::new(
+        (0..1000)
+            .map(|index| {
+                size(
+                    rems(25.).to_pixels(window.rem_size()),
+                    rems(if index % 5 == 0 { 2.75 } else { 1.75 }).to_pixels(window.rem_size()),
+                )
+            })
+            .collect(),
+    )
 }
 
 #[cfg(test)]
@@ -4236,19 +4368,118 @@ mod tests {
     }
 
     #[gpui_kit::test]
-    fn every_component_renders_in_both_themes(cx: &mut TestAppContext) {
+    fn zoom_controls_resize_rem_layout_and_reset(cx: &mut TestAppContext) {
+        cx.update(gpui_omarchy::init);
+        let (view, cx) = cx.add_window_view(Gallery::new);
+        view.update(cx, |this, cx| {
+            this.page = "virtual_list";
+            cx.notify();
+        });
+        cx.update(|window, cx| window.draw(cx).clear(cx));
+        for expected in [125, 150, 175, 200, 200] {
+            let point = cx.debug_bounds("zoom-in").unwrap().center();
+            cx.simulate_click(point, Default::default());
+            cx.update(|window, cx| {
+                window.draw(cx).clear(cx);
+                assert_eq!(view.read(cx).zoom_percent(window), expected);
+            });
+            let row = cx.debug_bounds("activity-row-0").unwrap();
+            assert_eq!(row.size.height, px(44. * expected as f32 / 100.));
+        }
+        let reset = cx.debug_bounds("zoom-reset").unwrap().center();
+        cx.simulate_click(reset, Default::default());
+        cx.update(|window, cx| {
+            window.draw(cx).clear(cx);
+            assert_eq!(view.read(cx).zoom_percent(window), 100);
+        });
+        for expected in [75, 50, 50] {
+            let point = cx.debug_bounds("zoom-out").unwrap().center();
+            cx.simulate_click(point, Default::default());
+            cx.update(|window, cx| {
+                window.draw(cx).clear(cx);
+                assert_eq!(view.read(cx).zoom_percent(window), expected);
+            });
+        }
+    }
+
+    #[gpui_kit::test]
+    fn zoom_shortcuts_work_while_editing_and_preserve_text(cx: &mut TestAppContext) {
+        cx.update(gpui_omarchy::init);
+        let (view, cx) = cx.add_window_view(Gallery::new);
+        cx.update(|window, cx| {
+            view.update(cx, |this, cx| {
+                this.page = "input";
+                this.input.update(cx, |state, cx| {
+                    state.set_value("Draft", window, cx);
+                    state.focus(window, cx);
+                });
+                cx.notify();
+            });
+            window.draw(cx).clear(cx);
+        });
+        let shortcuts = if cfg!(target_os = "macos") {
+            [
+                ("cmd-=", 125),
+                ("cmd--", 100),
+                ("cmd-=", 125),
+                ("cmd-0", 100),
+            ]
+        } else {
+            [
+                ("ctrl-=", 125),
+                ("ctrl--", 100),
+                ("ctrl-=", 125),
+                ("ctrl-0", 100),
+            ]
+        };
+        for (key, expected) in shortcuts {
+            cx.simulate_keystrokes(key);
+            cx.update(|window, cx| {
+                window.draw(cx).clear(cx);
+                assert_eq!(view.read(cx).zoom_percent(window), expected);
+                assert_eq!(view.read(cx).input.read(cx).value().as_ref(), "Draft");
+            });
+        }
+    }
+
+    #[gpui_kit::test]
+    fn virtual_rows_are_remeasured_after_rem_changes(cx: &mut TestAppContext) {
+        cx.update(gpui_omarchy::init);
+        let (view, cx) = cx.add_window_view(Gallery::new);
+        for rem_size in [16., 24., 20.] {
+            cx.update(|window, cx| {
+                window.set_rem_size(px(rem_size));
+                view.update(cx, |this, cx| {
+                    this.page = "virtual_list";
+                    cx.notify();
+                });
+                window.draw(cx).clear(cx);
+            });
+            let first = cx.debug_bounds("activity-row-0").unwrap();
+            let second = cx.debug_bounds("activity-row-1").unwrap();
+            assert_eq!(first.size.height, px(2.75 * rem_size));
+            assert_eq!(second.size.height, px(1.75 * rem_size));
+            assert_eq!(first.bottom(), second.top());
+        }
+    }
+
+    #[gpui_kit::test]
+    fn every_component_renders_in_both_themes_and_at_multiple_rem_sizes(cx: &mut TestAppContext) {
         cx.update(gpui_omarchy::init);
         let (view, cx) = cx.add_window_view(Gallery::new);
         for theme in [Theme::tokyo_night(), Theme::flexoki_light()] {
             cx.update(|_, cx| theme.apply(cx));
-            for page in components() {
-                cx.update(|window, cx| {
-                    view.update(cx, |this, cx| {
-                        this.page = page;
-                        cx.notify();
+            for rem_size in [16., 20., 24.] {
+                for page in components() {
+                    cx.update(|window, cx| {
+                        window.set_rem_size(px(rem_size));
+                        view.update(cx, |this, cx| {
+                            this.page = page;
+                            cx.notify();
+                        });
+                        window.draw(cx).clear(cx);
                     });
-                    window.draw(cx).clear(cx);
-                });
+                }
             }
         }
     }

--- a/src/button.rs
+++ b/src/button.rs
@@ -148,7 +148,9 @@ impl RenderOnce for Button {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui_kit::{Context, Modifiers, MouseButton, Render, TestAppContext, div, point, px};
+    use gpui_kit::px;
+    use gpui_kit::rems;
+    use gpui_kit::{Context, Modifiers, MouseButton, Render, TestAppContext, div, point};
     #[gpui_kit::test]
     fn disabled_button_suppresses_hover_and_pressed_geometry(cx: &mut TestAppContext) {
         cx.update(crate::init);
@@ -159,21 +161,21 @@ mod tests {
         impl Render for States {
             fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
                 let button = crate::button("button", "Apply", crate::ButtonVariant::Primary, cx)
-                    .w(px(100.))
-                    .h(px(40.));
+                    .w(rems(6.25))
+                    .h(rems(2.5));
                 let button = if self.disabled_first {
                     button
                         .disabled(self.disabled)
-                        .hover(|s| s.w(px(160.)))
-                        .active(|s| s.w(px(200.)))
+                        .hover(|s| s.w(rems(10.)))
+                        .active(|s| s.w(rems(12.5)))
                 } else {
                     button
-                        .hover(|s| s.w(px(160.)))
-                        .active(|s| s.w(px(200.)))
+                        .hover(|s| s.w(rems(10.)))
+                        .active(|s| s.w(rems(12.5)))
                         .disabled(self.disabled)
                 };
                 div()
-                    .size(px(400.))
+                    .size(rems(25.))
                     .child(button.debug_selector(|| "state-button".into()))
             }
         }

--- a/src/button_group.rs
+++ b/src/button_group.rs
@@ -4,7 +4,8 @@ use gpui_kit::base::{
     Radio, RadioGroup, Tabs,
     actions::{Confirm, SelectLeft, SelectRight},
 };
-use gpui_kit::{App, Context, ElementId, Entity, FocusHandle, KeyBinding, Window, prelude::*, px};
+use gpui_kit::rems;
+use gpui_kit::{App, Context, ElementId, Entity, FocusHandle, KeyBinding, Window, prelude::*};
 use std::rc::Rc;
 
 type Change = Rc<dyn Fn(usize, &mut Window, &mut App)>;
@@ -33,7 +34,7 @@ pub(crate) fn init(cx: &mut App) {
     ]);
 }
 
-/// A single-choice setting rendered as Omarchy's bordered ButtonGroup.
+/// A single-choice setting rendered as equal-width segments in a shared frame.
 /// The application owns `selected` and updates it in `on_change`.
 /// Left/Right (or h/l) move the cursor; Return/Space commit the choice.
 pub fn button_group(
@@ -67,13 +68,15 @@ pub fn button_group(
                 .tab_stop(false)
                 .flex()
                 .items_center()
-                .px(px(10.))
-                .py(px(6.))
+                .flex_1()
+                .justify_center()
+                .px_3()
+                .py_1()
                 .border_1()
-                .rounded(px(0.))
-                .border_color(t.control_border())
+                .rounded_none()
+                .border_color(t.foreground.opacity(0.))
                 .font_family(t.font.clone())
-                .text_size(px(12.))
+                .text_size(rems(0.75))
                 .text_color(t.foreground)
                 .bg(if selected == Some(index) {
                     t.selected_fill()
@@ -82,10 +85,12 @@ pub fn button_group(
                 })
                 .when(
                     focus.is_focused(window) && cursor.read(cx).index == Some(index),
-                    |row| row.bg(t.hover_fill()).border_color(t.focus_border()),
+                    |row| row.border_color(t.accent),
                 )
-                .hover(|row| row.bg(t.hover_fill()).border_color(t.focus_border()))
-                .active(|row| row.bg(t.pressed_fill()))
+                .when(!item.disabled, |row| {
+                    row.hover(|row| row.bg(t.hover_fill()))
+                        .active(|row| row.bg(t.pressed_fill()))
+                })
                 .styles(|styles| styles.disabled(|row| row.opacity(0.45)))
                 .child(item.label.clone())
                 .on_change(move |_, _, window, cx| {
@@ -99,8 +104,11 @@ pub fn button_group(
         RadioGroup::new(id)
             .axis(gpui_kit::Axis::Horizontal)
             .flex()
-            .flex_wrap()
-            .gap(px(6.))
+            .w_full()
+            .gap_1()
+            .p_1()
+            .border_1()
+            .border_color(t.divider())
             .children(rows),
         cursor,
         items,
@@ -111,10 +119,12 @@ pub fn button_group(
 
 /// A page tab list with the same restrained visual language and independent
 /// tab-list semantics. Use the selected value to render the associated panel.
+/// `show_shortcuts` renders one-based number hints; applications own key bindings.
 pub fn tab_list(
     id: impl Into<ElementId>,
     items: Vec<ChoiceItem>,
     selected: Option<usize>,
+    show_shortcuts: bool,
     on_change: impl Fn(usize, &mut Window, &mut App) + 'static,
     window: &mut Window,
     cx: &mut App,
@@ -126,7 +136,6 @@ pub fn tab_list(
             on_change(index, window, cx);
         }
     });
-    let t = cx.omarchy().clone();
     let count = items.len();
     let rows = items
         .iter()
@@ -138,13 +147,24 @@ pub fn tab_list(
                 .debug_selector(move || format!("omarchy-tab-{index}"))
                 .disabled(item.disabled)
                 .set_position(index + 1, count)
-                .when(
-                    focus.is_focused(window) && cursor.read(cx).index == Some(index),
-                    |tab| tab.bg(t.hover_fill()).border_color(t.focus_border()),
-                )
-                .on_click(move |_, window, cx| {
-                    focus.focus(window, cx);
-                    change(index, window, cx);
+                .when(show_shortcuts, |tab| {
+                    tab.child(
+                        gpui_kit::div()
+                            .self_start()
+                            .text_size(gpui_kit::rems(0.625))
+                            .child((index + 1).to_string()),
+                    )
+                })
+                .on_click({
+                    let cursor = cursor.clone();
+                    move |_, window, cx| {
+                        cursor.update(cx, |state, cx| {
+                            state.index = Some(index);
+                            cx.notify();
+                        });
+                        focus.focus(window, cx);
+                        change(index, window, cx);
+                    }
                 })
                 .into_any_element()
         })
@@ -276,8 +296,16 @@ mod tests {
                 })
             };
             let group = if self.tab_list {
-                tab_list("options", items, Some(self.selected), change, window, cx)
-                    .into_any_element()
+                tab_list(
+                    "options",
+                    items,
+                    Some(self.selected),
+                    true,
+                    change,
+                    window,
+                    cx,
+                )
+                .into_any_element()
             } else {
                 button_group("options", items, Some(self.selected), change, window, cx)
                     .into_any_element()
@@ -298,6 +326,27 @@ mod tests {
                 )
         }
     }
+    #[gpui_kit::test]
+    fn clicking_a_tab_moves_the_keyboard_cursor_to_it(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (view, cx) = cx.add_window_view(|_, cx| Harness {
+            tab_list: true,
+            selected: 0,
+            before: cx.focus_handle(),
+            after: cx.focus_handle(),
+        });
+        cx.update(|window, cx| window.draw(cx).clear(cx));
+        for (index, selector) in [(2, "omarchy-tab-2"), (0, "omarchy-tab-0")] {
+            let point = cx.debug_bounds(selector).unwrap().center();
+            cx.simulate_click(point, Default::default());
+            cx.update(|window, cx| window.draw(cx).clear(cx));
+            cx.simulate_keystrokes("enter");
+            cx.update(|_, cx| {
+                assert_eq!(view.read(cx).selected, index);
+            });
+        }
+    }
+
     #[gpui_kit::test]
     fn groups_have_one_tab_stop_and_skip_disabled_choices(cx: &mut TestAppContext) {
         cx.update(crate::init);

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -1,22 +1,23 @@
 //! Calendar presentation over gpui-base's date and view state.
 use crate::{ActiveTheme, IconName, icon};
 use gpui_kit::base::{Calendar, CalendarItemKind, CalendarState};
-use gpui_kit::{App, ElementId, Entity, Role, prelude::*, px};
+use gpui_kit::rems;
+use gpui_kit::{App, ElementId, Entity, Role, prelude::*};
 
 /// A calendar with selectable days, month/year navigation and range styling.
 /// Observe the supplied state or subscribe to base CalendarEvent::Selected.
 pub fn calendar(id: impl Into<ElementId>, state: &Entity<CalendarState>, cx: &App) -> Calendar {
     let t = cx.omarchy().clone();
     Calendar::new(id, state)
-        .w(px(248.))
-        .p(px(12.))
-        .gap(px(8.))
+        .w(rems(15.5))
+        .p(rems(0.75))
+        .gap(rems(0.5))
         .border_1()
-        .rounded(px(0.))
+        .rounded_none()
         .border_color(t.border)
         .bg(t.background)
         .font_family(t.font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
         .text_color(t.foreground)
         .label(|kind, value| match kind {
             CalendarItemKind::Weekday => {
@@ -48,10 +49,10 @@ pub fn calendar(id: impl Into<ElementId>, state: &Entity<CalendarState>, cx: &Ap
                 .flex()
                 .items_center()
                 .justify_center()
-                .h(px(28.))
-                .px(px(4.))
+                .h(rems(1.75))
+                .px(rems(0.25))
                 .border_1()
-                .rounded(px(0.))
+                .rounded_none()
                 .border_color(if state.is_today() {
                     t.accent
                 } else {
@@ -89,7 +90,7 @@ pub fn calendar(id: impl Into<ElementId>, state: &Entity<CalendarState>, cx: &Ap
                             | CalendarItemKind::Previous
                             | CalendarItemKind::Next
                     ),
-                    |item| item.w(px(32.)).flex_shrink_0(),
+                    |item| item.w(rems(2.)).flex_shrink_0(),
                 );
             if matches!(kind, CalendarItemKind::Previous | CalendarItemKind::Next) {
                 let previous = kind == CalendarItemKind::Previous;
@@ -114,7 +115,7 @@ pub fn calendar(id: impl Into<ElementId>, state: &Entity<CalendarState>, cx: &Ap
                         } else {
                             IconName::ChevronRight
                         })
-                        .size(px(14.)),
+                        .size(rems(0.875)),
                     );
             }
             item.into_any_element()

--- a/src/color_picker.rs
+++ b/src/color_picker.rs
@@ -1,7 +1,8 @@
 //! Color editing backed by base's hex validation and synchronized HSLA state.
 use crate::{ActiveTheme, ButtonVariant, button, input, popover_surface, slider};
 use gpui_kit::base::{ColorPicker, ColorPickerState, Popup};
-use gpui_kit::{App, ElementId, Entity, Focusable, Window, div, prelude::*, px};
+use gpui_kit::rems;
+use gpui_kit::{App, ElementId, Entity, Focusable, Window, div, prelude::*};
 
 pub fn color_picker(
     id: impl Into<ElementId>,
@@ -34,7 +35,7 @@ pub fn color_picker(
         .focusable(false)
         .child(
             div()
-                .size(px(16.))
+                .size(rems(1.))
                 .border_1()
                 .border_color(t.border)
                 .bg(color.unwrap_or(t.background)),
@@ -53,11 +54,11 @@ pub fn color_picker(
             .id("color-editor")
             .debug_selector(|| "color-picker-popup".into())
             .key_context("OmarchyPopoverContent")
-            .w(px(280.))
-            .mt(px(4.))
+            .w(rems(17.5))
+            .mt(rems(0.25))
             .flex()
             .flex_col()
-            .gap(px(6.))
+            .gap(rems(0.375))
             .on_mouse_down_out(move |_, window, cx| {
                 target.update(cx, |state, cx| {
                     restore_committed_color(state, window, cx);
@@ -82,10 +83,10 @@ pub fn color_picker(
             ("Opacity", channels.alpha()),
         ] {
             body = body.child(
-                div().flex().flex_col().gap(px(4.)).child(name).child(
+                div().flex().flex_col().gap(rems(0.25)).child(name).child(
                     div()
                         .debug_selector(move || format!("color-channel-{name}"))
-                        .child(slider(channel, false, window, cx).px(px(0.))),
+                        .child(slider(channel, false, window, cx).px(rems(0.))),
                 ),
             );
         }

--- a/src/controls.rs
+++ b/src/controls.rs
@@ -5,9 +5,10 @@ use gpui_kit::base::{
     Toggle,
 };
 use gpui_kit::prelude::FluentBuilder;
+use gpui_kit::rems;
 use gpui_kit::{
     App, ElementId, FontWeight, InteractiveElement, ParentElement, SharedString,
-    StatefulInteractiveElement, Styled, div, px,
+    StatefulInteractiveElement, Styled, div,
 };
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -42,11 +43,11 @@ pub fn button(
     Button::new(id)
         .accessibility_label(label.clone())
         .when(!label.is_empty(), |button| button.child(label))
-        .py(px(6.))
-        .px(px(10.))
-        .gap(px(8.))
+        .py(rems(0.375))
+        .px(rems(0.625))
+        .gap(rems(0.5))
         .border_1()
-        .rounded(px(0.))
+        .rounded_none()
         .border_color(if variant == ButtonVariant::Primary {
             t.accent
         } else if variant == ButtonVariant::Outline {
@@ -55,7 +56,7 @@ pub fn button(
             t.foreground.opacity(0.)
         })
         .font_family(t.font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
         .font_weight(FontWeight::NORMAL)
         .bg(bg)
         .text_color(fg)
@@ -81,23 +82,23 @@ pub fn checkbox(
         .accessibility_label(label.clone())
         .flex()
         .items_center()
-        .gap(px(8.))
-        .min_h(px(28.))
-        .px(px(4.))
+        .gap(rems(0.5))
+        .min_h(rems(1.75))
+        .px(rems(0.25))
         .border_1()
         .border_color(t.foreground.opacity(0.))
         .text_color(t.foreground)
         .font_family(t.font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
         .child(
             CheckboxIndicator::new()
                 .state(state)
-                .size(px(16.))
+                .size(rems(1.))
                 .flex_shrink_0()
                 .flex()
                 .items_center()
                 .justify_center()
-                .rounded(px(0.))
+                .rounded_none()
                 .border_1()
                 .border_color(t.control_border())
                 .bg(t.normal_fill())
@@ -119,7 +120,7 @@ pub fn checkbox(
                         } else {
                             IconName::Minus
                         })
-                        .size(px(14.))
+                        .size(rems(0.875))
                         .text_color(t.foreground),
                     )
                 }),
@@ -145,14 +146,14 @@ pub fn switch(
         .accessibility_label(label.clone())
         .flex()
         .items_center()
-        .gap(px(8.))
-        .py(px(5.))
-        .px(px(5.))
+        .gap(rems(0.5))
+        .py(rems(0.3125))
+        .px(rems(0.3125))
         .border_1()
         .border_color(t.foreground.opacity(0.))
         .text_color(t.foreground)
         .font_family(t.font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
         .hover(|s| s.bg(t.hover_fill()).border_color(t.focus_border()))
         .focus_visible(|s| s.bg(t.hover_fill()).border_color(t.focus_border()))
         .active(|s| s.bg(t.pressed_fill()))
@@ -160,17 +161,17 @@ pub fn switch(
         .child(
             SwitchTrack::new(id)
                 .checked(checked)
-                .w(px(42.))
-                .h(px(22.))
+                .w(rems(2.625))
+                .h(rems(1.375))
                 .flex_shrink_0()
-                .p(px(2.))
+                .p(rems(0.125))
                 .border_1()
                 .border_color(if checked {
                     t.foreground.opacity(0.)
                 } else {
                     t.control_border()
                 })
-                .rounded(px(0.))
+                .rounded_none()
                 .bg(if checked {
                     t.selected_fill()
                 } else {
@@ -178,10 +179,10 @@ pub fn switch(
                 })
                 .child(
                     SwitchThumb::new(checked)
-                        .size(px(16.))
-                        .rounded(px(0.))
+                        .size(rems(1.))
+                        .rounded_none()
                         .bg(if checked { t.foreground } else { t.secondary })
-                        .ml(px(if checked { 20. } else { 0. })),
+                        .ml(rems(if checked { 1.25 } else { 0. })),
                 ),
         )
         .child(label)
@@ -200,26 +201,26 @@ pub fn radio(
         .accessibility_label(label.clone())
         .flex()
         .items_center()
-        .gap(px(8.))
-        .min_h(px(28.))
-        .px(px(4.))
+        .gap(rems(0.5))
+        .min_h(rems(1.75))
+        .px(rems(0.25))
         .border_1()
         .border_color(t.foreground.opacity(0.))
         .text_color(t.foreground)
         .font_family(t.font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
         .child(
             div()
-                .size(px(16.))
+                .size(rems(1.))
                 .flex_shrink_0()
-                .rounded(px(0.))
+                .rounded_none()
                 .border_1()
                 .border_color(t.control_border())
                 .flex()
                 .items_center()
                 .justify_center()
                 .when(checked, |s| {
-                    s.child(div().size(px(8.)).rounded(px(0.)).bg(t.foreground))
+                    s.child(div().size(rems(0.5)).rounded_none().bg(t.foreground))
                 }),
         )
         .child(label)
@@ -242,15 +243,15 @@ pub fn toggle(
         .accessibility_label(label.clone())
         .flex()
         .items_center()
-        .gap(px(8.))
-        .py(px(6.))
-        .px(px(10.))
+        .gap(rems(0.5))
+        .py(rems(0.375))
+        .px(rems(0.625))
         .border_1()
-        .rounded(px(0.))
+        .rounded_none()
         .border_color(t.border)
         .text_color(t.foreground)
         .font_family(t.font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
         .font_weight(FontWeight::NORMAL)
         .child(label)
         .hover(|s| s.bg(t.hover_fill()).border_color(t.focus_border()))
@@ -270,9 +271,9 @@ pub fn toggle_group(id: impl Into<ElementId>, cx: &App) -> gpui_kit::base::Toggl
         .flex()
         .flex_wrap()
         .items_center()
-        .gap(px(6.))
+        .gap(rems(0.375))
         .font_family(t.font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
         .text_color(t.foreground)
 }
 
@@ -291,25 +292,32 @@ pub fn link(
         .child(label)
         .flex()
         .items_center()
-        .gap(px(6.))
-        .text_size(px(12.))
+        .gap(rems(0.375))
+        .text_size(rems(0.75))
         .font_family(t.font.clone())
         .text_color(t.accent)
         .underline()
         .border_1()
         .border_color(t.foreground.opacity(0.))
-        .px(px(4.))
-        .py(px(6.))
+        .px(rems(0.25))
+        .py(rems(0.375))
         .hover(|s| s.text_color(t.bright))
         .focus_visible(|s| s.bg(t.hover_fill()).border_color(t.focus_border()))
         .styles(|s| s.disabled(|s| s.opacity(0.45)))
 }
 
-/// Omarchy ButtonGroup presentation with gpui-base Tab semantics.
-/// The source shell has no separate Tabs primitive: bordered peers use a quiet
-/// selected fill. The native port keeps label weight stable across selection.
-pub fn tabs(id: impl Into<ElementId>, _cx: &App) -> Tabs {
-    Tabs::new(id).flex().flex_wrap().gap(px(6.))
+/// A square segmented strip with gpui-base Tab semantics.
+pub fn tabs(id: impl Into<ElementId>, cx: &App) -> Tabs {
+    let t = cx.omarchy();
+    Tabs::new(id)
+        .flex()
+        .items_center()
+        .gap_1()
+        .p_1()
+        .border_1()
+        .rounded_none()
+        .border_color(t.divider())
+        .bg(t.normal_fill())
 }
 
 pub fn tab(
@@ -324,22 +332,25 @@ pub fn tab(
         .selected(selected)
         .accessibility_label(label.clone())
         .child(label)
-        .px(px(10.))
-        .py(px(6.))
+        .px_3()
+        .py_1()
         .flex()
+        .flex_shrink_0()
         .items_center()
+        .gap_1()
         .border_1()
-        .rounded(px(0.))
-        .border_color(t.control_border())
-        .text_size(px(12.))
+        .rounded_none()
+        .border_color(t.foreground.opacity(0.))
         .font_family(t.font.clone())
         .font_weight(FontWeight::NORMAL)
-        .text_color(t.foreground)
-        .hover(|s| s.bg(t.hover_fill()).border_color(t.focus_border()))
-        .focus_visible(|s| s.bg(t.hover_fill()).border_color(t.focus_border()))
+        .text_color(t.secondary)
         .active(|s| s.bg(t.pressed_fill()))
         .styles(|s| {
-            s.selected(|s| s.bg(t.selected_fill()))
-                .disabled(|s| s.opacity(0.45))
+            s.selected(|s| {
+                s.bg(t.selected_fill())
+                    .text_color(t.foreground)
+                    .border_color(t.accent)
+            })
+            .disabled(|s| s.opacity(0.45))
         })
 }

--- a/src/date_picker.rs
+++ b/src/date_picker.rs
@@ -1,7 +1,8 @@
 use crate::{ButtonVariant, IconName, button, calendar, icon};
 use gpui_kit::base::{CalendarEvent, CalendarState, DatePicker, Popup};
+use gpui_kit::rems;
 use gpui_kit::{
-    App, Context, ElementId, Entity, FocusHandle, MouseButton, Window, div, prelude::*, px,
+    App, Context, ElementId, Entity, FocusHandle, MouseButton, Window, div, prelude::*,
 };
 
 pub struct DatePickerState {
@@ -96,7 +97,7 @@ pub fn date_picker(
         .w_full()
         .justify_start()
         .child(div().flex_1().child(label))
-        .child(icon(IconName::Calendar).size(px(14.)))
+        .child(icon(IconName::Calendar).size(rems(0.875)))
         .on_click(move |_, window, cx| {
             // Route pointer activation through the base root so builder refinements
             // such as `.disabled(true)` govern both keyboard and mouse behavior.
@@ -117,7 +118,7 @@ pub fn date_picker(
                 .id("date-calendar-popup")
                 .key_context("OmarchyPopoverContent")
                 .occlude()
-                .mt(px(4.))
+                .mt(rems(0.25))
                 .on_mouse_down_out(move |_, window, cx| {
                     target.update(cx, |state, cx| state.set_open(false, window, cx))
                 })
@@ -128,7 +129,7 @@ pub fn date_picker(
     let target = state.clone();
     DatePicker::new(id, &focus)
         .open(open)
-        .w(px(248.))
+        .w(rems(15.5))
         .key_context("OmarchyDatePicker")
         .on_open_change(move |open, window, cx| {
             target.update(cx, |state, cx| state.set_open(open, window, cx))
@@ -139,6 +140,7 @@ pub fn date_picker(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gpui_kit::px;
     use gpui_kit::{Render, TestAppContext};
 
     struct Harness {

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -3,7 +3,8 @@ use crate::ActiveTheme;
 use gpui_kit::base::{
     AlertDialog, Dialog, DialogBackdrop, DialogDescription, DialogPopup, DialogTitle,
 };
-use gpui_kit::{App, FocusHandle, FontWeight, ParentElement, SharedString, Styled, px, rgb};
+use gpui_kit::rems;
+use gpui_kit::{App, FocusHandle, FontWeight, ParentElement, SharedString, Styled, rgb};
 
 /// Supply a stable focus handle, focus it on opening, and restore trigger focus on close.
 /// Base owns the focus trap, Escape, confirmation and backdrop dismissal.
@@ -38,22 +39,22 @@ pub fn dialog_popup(cx: &App) -> DialogPopup {
         .relative()
         .flex()
         .flex_col()
-        .gap(px(14.))
-        .w(px(420.))
+        .gap(rems(0.875))
+        .w(rems(26.25))
         .max_w(gpui_kit::relative(1.))
-        .p(px(18.))
+        .p(rems(1.125))
         .border_1()
         .border_color(t.border)
-        .rounded(px(0.))
+        .rounded_none()
         .bg(t.background)
         .text_color(t.foreground)
         .font_family(t.font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
 }
 
 pub fn dialog_title(title: impl Into<SharedString>, cx: &App) -> DialogTitle {
     DialogTitle::new()
-        .text_size(px(16.))
+        .text_size(rems(1.))
         .font_weight(FontWeight::BOLD)
         .text_color(cx.omarchy().foreground)
         .child(title.into())

--- a/src/dock.rs
+++ b/src/dock.rs
@@ -1,9 +1,8 @@
 //! Dock presentation. Layout, reconciliation and drag operations stay in base.
 use crate::{ActiveTheme, ButtonVariant, button};
 use gpui_kit::base::dock::*;
-use gpui_kit::{
-    AnyElement, App, Context, Div, SharedString, Stateful, Window, div, prelude::*, px,
-};
+use gpui_kit::rems;
+use gpui_kit::{AnyElement, App, Context, Div, SharedString, Stateful, Window, div, prelude::*};
 use std::rc::Rc;
 
 pub fn dock_area(
@@ -24,7 +23,7 @@ impl DockAreaRenderer for OmarchyDock {
             .border_color(t.border)
             .bg(t.background)
             .font_family(t.font.clone())
-            .text_size(px(12.))
+            .text_size(rems(0.75))
             .text_color(t.foreground)
     }
     fn tiles_renderer(&self) -> Rc<dyn TilesRenderer> {
@@ -42,8 +41,8 @@ impl TabGroupRenderer for OmarchyDock {
             .id("dock-tab-bar")
             .flex()
             .items_center()
-            .gap(px(6.))
-            .p(px(6.))
+            .gap(rems(0.375))
+            .p(rems(0.375))
             .border_b_1()
             .border_color(t.border)
             .bg(t.normal_fill());
@@ -109,8 +108,8 @@ struct DockDragLabel(&'static str);
 impl gpui_kit::Render for DockDragLabel {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         div()
-            .px(px(10.))
-            .py(px(6.))
+            .px(rems(0.625))
+            .py(rems(0.375))
             .border_1()
             .border_color(cx.omarchy().accent)
             .bg(cx.omarchy().background)

--- a/src/hover_card.rs
+++ b/src/hover_card.rs
@@ -1,6 +1,7 @@
 use crate::popover_surface;
 use gpui_kit::base::{HoverCard, HoverCardState};
-use gpui_kit::{ElementId, IntoElement, ParentElement, Styled, prelude::*, px};
+use gpui_kit::rems;
+use gpui_kit::{ElementId, IntoElement, ParentElement, Styled, prelude::*};
 use std::time::Duration;
 
 /// Supplementary hover content. Keep essential information available inline.
@@ -22,7 +23,7 @@ pub fn hover_card<E: IntoElement>(
             let body = content(state, window, cx);
             popover_surface(cx)
                 .id("hover-card-surface")
-                .mt(px(4.))
+                .mt(rems(0.25))
                 .child(body)
         })
 }

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -1,6 +1,7 @@
 //! GPUI Kit's bundled icons, resolved against the current text color at render time.
 use gpui_kit::base::StyledExt;
-use gpui_kit::{App, IntoElement, RenderOnce, StyleRefinement, Styled, Window, px, svg};
+use gpui_kit::rems;
+use gpui_kit::{App, IntoElement, RenderOnce, StyleRefinement, Styled, Window, svg};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum IconName {
@@ -94,7 +95,7 @@ pub fn icon(name: IconName) -> Icon {
         name,
         style: StyleRefinement::default(),
     }
-    .size(px(16.))
+    .size(rems(1.))
     .flex_shrink_0()
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,13 +1,68 @@
 //! Native text editing, selection, clipboard and IME supplied by gpui-base.
 use crate::ActiveTheme;
 use gpui_kit::base::{
-    Input, InputBase, Textarea,
+    Input as BaseInput, InputBase, Textarea,
     input::{InputState, TextareaState},
 };
+use gpui_kit::rems;
 use gpui_kit::{
-    App, ElementId, Entity, Focusable, InteractiveElement, MouseButton, ParentElement, Styled,
-    Window, px,
+    AnyElement, App, ElementId, Entity, Focusable, InteractiveElement, Interactivity, IntoElement,
+    MouseButton, ParentElement, RenderOnce, StatefulInteractiveElement, StyleRefinement, Styled,
+    Window, div,
 };
+
+/// A native single-line editor with optional, non-editable prefix and suffix slots.
+/// The caller retains the `InputState`; affixes never become part of its value.
+#[derive(IntoElement)]
+pub struct Input {
+    base: InputBase,
+    editor: BaseInput,
+    prefix: Option<AnyElement>,
+    suffix: Option<AnyElement>,
+}
+
+impl Input {
+    pub fn prefix(mut self, content: impl IntoElement) -> Self {
+        self.prefix = Some(content.into_any_element());
+        self
+    }
+
+    pub fn suffix(mut self, content: impl IntoElement) -> Self {
+        self.suffix = Some(content.into_any_element());
+        self
+    }
+}
+
+impl Styled for Input {
+    fn style(&mut self) -> &mut StyleRefinement {
+        self.base.style()
+    }
+}
+
+impl InteractiveElement for Input {
+    fn interactivity(&mut self) -> &mut Interactivity {
+        self.base.interactivity()
+    }
+}
+
+impl StatefulInteractiveElement for Input {}
+
+impl RenderOnce for Input {
+    fn render(self, _: &mut Window, cx: &mut App) -> impl IntoElement {
+        let affix = |content| {
+            div()
+                .flex()
+                .items_center()
+                .flex_shrink_0()
+                .text_color(cx.omarchy().secondary)
+                .child(content)
+        };
+        self.base
+            .children(self.prefix.map(affix))
+            .child(div().flex_1().min_w_0().child(self.editor))
+            .children(self.suffix.map(affix))
+    }
+}
 
 fn frame(id: impl Into<ElementId>, focused: bool, cx: &App) -> InputBase {
     let t = cx.omarchy();
@@ -15,14 +70,14 @@ fn frame(id: impl Into<ElementId>, focused: bool, cx: &App) -> InputBase {
         .focused(focused)
         .w_full()
         .min_w_0()
-        .px(px(10.))
+        .px(rems(0.625))
         .border_1()
-        .rounded(px(0.))
+        .rounded_none()
         .border_color(t.control_border())
         .bg(t.normal_fill())
         .text_color(t.foreground)
         .font_family(t.font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
         .styles(|s| s.focused(|s| s.bg(t.hover_fill()).border_color(t.focus_border())))
 }
 
@@ -31,19 +86,25 @@ pub fn input(
     state: &Entity<InputState>,
     window: &Window,
     cx: &mut App,
-) -> InputBase {
+) -> Input {
     let style = cx.omarchy().input_style();
     state.update(cx, |state, _| state.set_editor_style(style));
     let focused = state.read(cx).focus_handle(cx).is_focused(window);
     let target = state.clone();
-    frame(id, focused, cx)
-        .py(px(7.))
+    let base = frame(id, focused, cx)
+        .py(rems(0.4375))
         .flex()
         .items_center()
+        .gap_2()
         .on_mouse_down(MouseButton::Left, move |_, window, cx| {
             target.update(cx, |state, cx| state.focus(window, cx));
-        })
-        .child(Input::new(state))
+        });
+    Input {
+        base,
+        editor: BaseInput::new(state),
+        prefix: None,
+        suffix: None,
+    }
 }
 
 pub fn textarea(
@@ -57,8 +118,8 @@ pub fn textarea(
     let focused = state.read(cx).focus_handle(cx).is_focused(window);
     let target = state.clone();
     frame(id, focused, cx)
-        .min_h(px(96.))
-        .py(px(7.))
+        .min_h(rems(6.))
+        .py(rems(0.4375))
         .on_mouse_down(MouseButton::Left, move |_, window, cx| {
             target.update(cx, |state, cx| state.focus(window, cx));
         })
@@ -75,40 +136,101 @@ pub fn number_input(state: &Entity<InputState>, cx: &mut App) -> gpui_kit::base:
     });
     let minus = t.clone();
     gpui_kit::base::NumberInput::new(state)
-        .w(px(120.))
-        .h(px(28.))
+        .w(rems(7.5))
+        .h(rems(1.75))
         .flex()
         .items_center()
         .border_1()
-        .rounded(px(0.))
+        .rounded_none()
         .border_color(t.control_border())
         .bg(t.normal_fill())
         .text_color(t.foreground)
         .font_family(t.font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
         .input(
             gpui_kit::div()
                 .flex_1()
                 .min_w_0()
-                .px(px(10.))
-                .child(Input::new(state)),
+                .px(rems(0.625))
+                .child(BaseInput::new(state)),
         )
         .decrement_button(move |button| {
             button
-                .w(px(28.))
+                .w(rems(1.75))
                 .h_full()
                 .text_color(minus.foreground)
                 .bg(minus.surface)
                 .hover(|s| s.bg(minus.selection))
-                .child(crate::icon(crate::IconName::Minus).size(px(12.)))
+                .child(crate::icon(crate::IconName::Minus).size(rems(0.75)))
         })
         .increment_button(move |button| {
             button
-                .w(px(28.))
+                .w(rems(1.75))
                 .h_full()
                 .text_color(t.foreground)
                 .bg(t.surface)
                 .hover(|s| s.bg(t.selection))
-                .child(crate::icon(crate::IconName::Plus).size(px(12.)))
+                .child(crate::icon(crate::IconName::Plus).size(rems(0.75)))
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui_kit::{Context, Modifiers, Render, TestAppContext, prelude::*};
+
+    struct Harness(Entity<InputState>);
+
+    impl Render for Harness {
+        fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            input("price", &self.0, window, cx)
+                .debug_selector(|| "price-frame".into())
+                .w(rems(15.))
+                .prefix(div().debug_selector(|| "price-prefix".into()).child("$"))
+                .suffix(div().debug_selector(|| "price-suffix".into()).child("USD"))
+        }
+    }
+
+    #[gpui_kit::test]
+    fn input_and_affixes_scale_with_the_window_rem(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (view, cx) = cx.add_window_view(|window, cx| {
+            Harness(cx.new(|cx| InputState::new(window, cx).default_value("181.170")))
+        });
+        let mut previous_suffix_width = gpui_kit::Pixels::ZERO;
+        for rem_size in [16., 20., 24.] {
+            cx.update(|window, cx| {
+                window.set_rem_size(gpui_kit::px(rem_size));
+                view.update(cx, |_, cx| cx.notify());
+                window.draw(cx).clear(cx);
+            });
+            let frame = cx.debug_bounds("price-frame").unwrap();
+            let prefix = cx.debug_bounds("price-prefix").unwrap();
+            let suffix = cx.debug_bounds("price-suffix").unwrap();
+            assert_eq!(frame.size.width, gpui_kit::px(15. * rem_size));
+            assert!(suffix.size.width > previous_suffix_width);
+            assert!(prefix.right() < suffix.left());
+            assert!(suffix.right() < frame.right());
+            previous_suffix_width = suffix.size.width;
+        }
+    }
+
+    #[gpui_kit::test]
+    fn affixes_preserve_editing_and_focus(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (view, cx) =
+            cx.add_window_view(|window, cx| Harness(cx.new(|cx| InputState::new(window, cx))));
+        cx.update(|window, cx| window.draw(cx).clear(cx));
+        let prefix = cx.debug_bounds("price-prefix").unwrap();
+        let suffix = cx.debug_bounds("price-suffix").unwrap();
+        assert!(prefix.right() < suffix.left());
+        cx.simulate_click(suffix.center(), Modifiers::default());
+        cx.update(|window, cx| {
+            assert!(view.read(cx).0.read(cx).focus_handle(cx).is_focused(window));
+        });
+        cx.simulate_input("181.170");
+        cx.update(|_, cx| {
+            assert_eq!(view.read(cx).0.read(cx).value().as_ref(), "181.170");
+        });
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub use dock::dock_area;
 pub use focus::focus_scope;
 pub use hover_card::hover_card;
 pub use icon::{IconName, icon};
-pub use input::{input, number_input, textarea};
+pub use input::{Input, input, number_input, textarea};
 pub use link::Link;
 pub use list::{scrollbar, virtual_list};
 pub use menu::{MenuItem, menu};

--- a/src/link.rs
+++ b/src/link.rs
@@ -133,7 +133,9 @@ impl RenderOnce for Link {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui_kit::{Context, Modifiers, MouseButton, Render, TestAppContext, div, point, px};
+    use gpui_kit::px;
+    use gpui_kit::rems;
+    use gpui_kit::{Context, Modifiers, MouseButton, Render, TestAppContext, div, point};
     #[gpui_kit::test]
     fn disabled_link_suppresses_hover_and_pressed_geometry(cx: &mut TestAppContext) {
         cx.update(crate::init);
@@ -144,19 +146,19 @@ mod tests {
         impl Render for States {
             fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
                 let link = crate::link("link", "Project", "https://example.com", cx)
-                    .w(px(100.))
-                    .h(px(40.));
+                    .w(rems(6.25))
+                    .h(rems(2.5));
                 let link = if self.disabled_first {
                     link.disabled(self.disabled)
-                        .hover(|s| s.w(px(160.)))
-                        .active(|s| s.w(px(200.)))
+                        .hover(|s| s.w(rems(10.)))
+                        .active(|s| s.w(rems(12.5)))
                 } else {
-                    link.hover(|s| s.w(px(160.)))
-                        .active(|s| s.w(px(200.)))
+                    link.hover(|s| s.w(rems(10.)))
+                        .active(|s| s.w(rems(12.5)))
                         .disabled(self.disabled)
                 };
                 div()
-                    .size(px(400.))
+                    .size(rems(25.))
                     .child(link.debug_selector(|| "state-link".into()))
             }
         }

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,7 +1,8 @@
 //! Virtualized lists retain base's sizing and scroll model.
 use crate::ActiveTheme;
+use gpui_kit::rems;
 use gpui_kit::{
-    App, Context, ElementId, Entity, IntoElement, Pixels, Render, Size, Styled, Window, px,
+    App, Context, ElementId, Entity, IntoElement, Pixels, Render, Size, Styled, Window,
 };
 use std::{ops::Range, rc::Rc};
 
@@ -18,9 +19,9 @@ pub fn virtual_list<V: Render, R: IntoElement>(
     let t = cx.omarchy();
     gpui_kit::base::v_virtual_list(view, id, sizes, render)
         .w_full()
-        .h(px(280.))
+        .h(rems(17.5))
         .font_family(t.font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
         .text_color(t.foreground)
         .bg(t.background)
 }
@@ -31,6 +32,7 @@ pub fn scrollbar<H: gpui_kit::base::ScrollbarHandle + Clone>(
     id: impl Into<ElementId>,
     axis: gpui_kit::base::ScrollbarAxis,
     handle: &H,
+    window: &Window,
     cx: &App,
 ) -> gpui_kit::base::Scrollbar {
     let t = cx.omarchy();
@@ -40,12 +42,16 @@ pub fn scrollbar<H: gpui_kit::base::ScrollbarHandle + Clone>(
         .mode(gpui_kit::base::ScrollbarMode::Always)
         .styles(|style| {
             style
-                .track(|track| track.width(px(8.)).bg(t.normal_fill()))
+                .track(|track| {
+                    track
+                        .width(rems(0.5).to_pixels(window.rem_size()))
+                        .bg(t.normal_fill())
+                })
                 .thumb(|thumb| {
                     thumb
-                        .width(px(6.))
-                        .inset(px(1.))
-                        .radius(px(0.))
+                        .width(rems(0.375).to_pixels(window.rem_size()))
+                        .inset(rems(0.0625).to_pixels(window.rem_size()))
+                        .radius(Pixels::ZERO)
                         .bg(t.foreground.opacity(0.35))
                 })
                 .thumb_hover(|thumb| thumb.bg(t.foreground.opacity(0.55)))

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,9 +1,9 @@
 //! A keyboard menu composed from the base Popover and Button primitives.
 use crate::{ActiveTheme, ButtonVariant, IconName, button, icon};
 use gpui_kit::base::Popover;
+use gpui_kit::rems;
 use gpui_kit::{
     App, ElementId, Focusable, KeyDownEvent, ParentElement, SharedString, Window, div, prelude::*,
-    px,
 };
 use std::rc::Rc;
 
@@ -87,17 +87,17 @@ pub fn menu(
                 .debug_selector(|| "omarchy-menu-content".into())
                 .role(gpui_kit::Role::Menu)
                 .track_focus(&focus)
-                .w(px(240.))
-                .p(px(6.))
+                .w(rems(15.))
+                .p(rems(0.375))
                 .flex()
                 .flex_col()
-                .gap(px(2.))
+                .gap(rems(0.125))
                 .border_1()
                 .border_color(t.border)
                 .bg(t.background)
                 .text_color(t.foreground)
                 .font_family(t.font.clone())
-                .text_size(px(12.))
+                .text_size(rems(0.75))
                 .on_action(move |_: &gpui_kit::base::actions::Confirm, window, cx| {
                     if let Some(index) = *confirm_cursor.read(cx) {
                         confirm_close.update(cx, |state, cx| state.dismiss(window, cx));
@@ -153,9 +153,9 @@ pub fn menu(
                         .focusable(false)
                         .disabled(item.disabled)
                         .w_full()
-                        .h(px(28.))
-                        .py(px(0.))
-                        .px(px(8.))
+                        .h(rems(1.75))
+                        .py(rems(0.))
+                        .px(rems(0.5))
                         .justify_start()
                         .bg(if current {
                             t.hover_fill()
@@ -166,23 +166,23 @@ pub fn menu(
                         .when(has_icons, |row| {
                             row.child(
                                 div()
-                                    .w(px(14.))
+                                    .w(rems(0.875))
                                     .flex_shrink_0()
                                     .when_some(item.icon, |slot, name| {
-                                        slot.child(icon(name).size(px(14.)))
+                                        slot.child(icon(name).size(rems(0.875)))
                                     }),
                             )
                         })
                         .child(div().flex_1().min_w_0().child(item.label))
                         .when_some(item.checked, |row, checked| {
-                            row.child(div().w(px(14.)).when(checked, |slot| {
-                                slot.child(icon(IconName::Check).size(px(14.)))
+                            row.child(div().w(rems(0.875)).when(checked, |slot| {
+                                slot.child(icon(IconName::Check).size(rems(0.875)))
                             }))
                         })
                         .when_some(item.shortcut, |row, shortcut| {
                             row.child(
                                 div()
-                                    .text_size(px(11.))
+                                    .text_size(rems(0.6875))
                                     .text_color(t.secondary)
                                     .child(shortcut),
                             )
@@ -203,7 +203,7 @@ pub fn menu(
                         });
                     div()
                         .when(item.separator_before, |group| {
-                            group.child(div().py(px(4.)).child(crate::separator(cx)))
+                            group.child(div().py(rems(0.25)).child(crate::separator(cx)))
                         })
                         .child(row)
                 }))

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -3,9 +3,10 @@ use crate::{ActiveTheme, ButtonVariant, button};
 use gpui_kit::base::{
     Accordion, AccordionPanel, AccordionTrigger, Pagination, PaginationItem, PaginationState,
 };
+use gpui_kit::rems;
 use gpui_kit::{
     App, ElementId, FontWeight, InteractiveElement, IntoElement, ParentElement, SharedString,
-    Styled, div, px,
+    Styled, div,
 };
 
 pub fn accordion(id: impl Into<ElementId>, cx: &App) -> Accordion {
@@ -27,13 +28,13 @@ pub fn accordion_trigger(
         .flex()
         .items_center()
         .justify_between()
-        .h(px(32.))
-        .px(px(8.))
+        .h(rems(2.))
+        .px(rems(0.5))
         .border_2()
         .border_color(t.background)
         .text_color(t.foreground)
         .font_family(t.font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
         .font_weight(FontWeight::BOLD)
         .hover(|s| s.bg(t.surface))
         .focus_visible(|s| s.border_color(t.accent))
@@ -48,11 +49,11 @@ pub fn accordion_trigger(
 pub fn accordion_panel(cx: &App) -> AccordionPanel {
     let t = cx.omarchy();
     AccordionPanel::new()
-        .px(px(10.))
-        .py(px(8.))
+        .px(rems(0.625))
+        .py(rems(0.5))
         .border_b_1()
         .border_color(t.border)
-        .text_size(px(12.))
+        .text_size(rems(0.75))
         .font_family(t.font.clone())
         .text_color(t.secondary)
 }
@@ -63,7 +64,7 @@ pub fn pagination(id: impl Into<ElementId>, state: PaginationState, cx: &App) ->
         .flex()
         .flex_wrap()
         .items_center()
-        .gap(px(4.))
+        .gap(rems(0.25))
         .children(items.into_iter().map(|item| {
             match item {
                 PaginationItem::Page(page) => {
@@ -75,13 +76,13 @@ pub fn pagination(id: impl Into<ElementId>, state: PaginationState, cx: &App) ->
                         cx,
                     )
                     .selected(page == state.current_page())
-                    .w(px(32.))
-                    .px(px(0.))
+                    .w(rems(2.))
+                    .px(rems(0.))
                     .on_click(move |_, window, cx| state.request_page(page, window, cx))
                     .into_any_element()
                 }
                 PaginationItem::Ellipsis(_) => div()
-                    .w(px(24.))
+                    .w(rems(1.5))
                     .text_color(cx.omarchy().secondary)
                     .child("…")
                     .into_any_element(),
@@ -96,10 +97,10 @@ pub fn collapsible(open: bool, cx: &App) -> gpui_kit::base::Collapsible {
         .open(open)
         .flex()
         .flex_col()
-        .gap(px(14.))
+        .gap(rems(0.875))
         .w_full()
         .text_color(cx.omarchy().foreground)
-        .text_size(px(12.))
+        .text_size(rems(0.75))
 }
 
 /// Stateful page navigation with the base push/pop/forward lifecycle.
@@ -110,11 +111,11 @@ pub fn nav_stack(
     let t = cx.omarchy();
     gpui_kit::base::NavStack::new(state)
         .w_full()
-        .h(px(280.))
+        .h(rems(17.5))
         .border_1()
         .border_color(t.border)
         .bg(t.background)
         .font_family(t.font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
         .text_color(t.foreground)
 }

--- a/src/otp_input.rs
+++ b/src/otp_input.rs
@@ -1,6 +1,7 @@
 use crate::ActiveTheme;
 use gpui_kit::base::{OtpState, StyledExt as _};
-use gpui_kit::{App, Entity, Focusable, MouseButton, Window, div, prelude::*, px};
+use gpui_kit::rems;
+use gpui_kit::{App, Entity, Focusable, MouseButton, Window, div, prelude::*};
 
 /// Numeric code entry using base state, with clipboard support and inert disabled cells.
 #[derive(IntoElement)]
@@ -67,13 +68,13 @@ impl RenderOnce for OtpInput {
                 .map(|ch| if value.is_masked() { '•' } else { *ch });
             cells.push(
                 div()
-                    .w(px(32.))
-                    .h(px(36.))
+                    .w(rems(2.))
+                    .h(rems(2.25))
                     .flex()
                     .items_center()
                     .justify_center()
                     .border_1()
-                    .rounded(px(0.))
+                    .rounded_none()
                     .border_color(if current {
                         t.accent
                     } else {
@@ -81,7 +82,7 @@ impl RenderOnce for OtpInput {
                     })
                     .bg(t.normal_fill())
                     .font_family(t.font.clone())
-                    .text_size(px(16.))
+                    .text_size(rems(1.))
                     .text_color(t.foreground)
                     .when(!self.disabled, |cell| {
                         cell.on_mouse_down(MouseButton::Left, move |_, window, cx| {
@@ -96,7 +97,7 @@ impl RenderOnce for OtpInput {
         if self.disabled {
             return div()
                 .flex()
-                .gap(px(6.))
+                .gap(rems(0.375))
                 .children(cells)
                 .refine_style(&self.style)
                 .opacity(0.45)
@@ -172,7 +173,7 @@ impl RenderOnce for OtpInput {
             .child(
                 gpui_kit::base::OtpInput::new(&state)
                     .flex()
-                    .gap(px(6.))
+                    .gap(rems(0.375))
                     .children(cells)
                     .refine_style(&self.style),
             )
@@ -183,6 +184,7 @@ impl RenderOnce for OtpInput {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gpui_kit::px;
     use gpui_kit::{Context, Render, TestAppContext};
     struct Harness {
         state: Entity<OtpState>,

--- a/src/popover.rs
+++ b/src/popover.rs
@@ -1,7 +1,8 @@
 //! Contextual controls in an anchored, non-modal surface.
 use crate::ActiveTheme;
 use gpui_kit::base::{Popover, PopoverState};
-use gpui_kit::{App, Context, Div, ElementId, Window, div, prelude::*, px};
+use gpui_kit::rems;
+use gpui_kit::{App, Context, Div, ElementId, Window, div, prelude::*};
 
 pub(crate) fn init(cx: &mut App) {
     // Suppress the outer Popover toggle bindings inside its content. Deeper
@@ -38,17 +39,17 @@ pub fn popover_surface(cx: &App) -> Div {
     div()
         .flex()
         .flex_col()
-        .gap(px(14.))
-        .w(px(280.))
+        .gap(rems(0.875))
+        .w(rems(17.5))
         .max_w(gpui_kit::relative(1.))
-        .p(px(14.))
+        .p(rems(0.875))
         .border_1()
-        .rounded(px(0.))
+        .rounded_none()
         .border_color(t.border)
         .bg(t.background)
         .text_color(t.foreground)
         .font_family(t.font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
 }
 
 #[cfg(test)]

--- a/src/resizable.rs
+++ b/src/resizable.rs
@@ -1,6 +1,7 @@
 use crate::ActiveTheme;
 use gpui_kit::base::{ResizablePanel, ResizablePanelGroup};
-use gpui_kit::{App, Axis, ElementId, div, prelude::*, px};
+use gpui_kit::rems;
+use gpui_kit::{App, Axis, ElementId, div, prelude::*};
 use std::rc::Rc;
 
 /// Resizable panes with a fine divider and base-owned drag hit area and limits.
@@ -17,10 +18,10 @@ pub fn resizable(id: impl Into<ElementId>, axis: Axis, cx: &App) -> ResizablePan
                         t.border
                     })
                     .when(handle.axis() == Axis::Horizontal, |line| {
-                        line.w(px(1.)).h_full()
+                        line.w(rems(0.0625)).h_full()
                     })
                     .when(handle.axis() == Axis::Vertical, |line| {
-                        line.h(px(1.)).w_full()
+                        line.h(rems(0.0625)).w_full()
                     })
                     .into_any_element(),
             )
@@ -35,20 +36,24 @@ pub fn resizable_panel() -> ResizablePanel {
 mod tests {
     use super::*;
     use gpui_kit::base::ResizableState;
+    use gpui_kit::px;
     use gpui_kit::{Context, Entity, MouseButton, Render, TestAppContext, Window, point};
     struct Harness {
         state: Entity<ResizableState>,
         axis: Axis,
     }
     impl Render for Harness {
-        fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-            div().size(px(400.)).child(
+        fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            div().size(rems(25.)).child(
                 resizable("split", self.axis, cx)
                     .with_state(&self.state)
                     .child(
                         resizable_panel()
-                            .size(px(160.))
-                            .size_range(px(120.)..px(260.))
+                            .size(rems(10.).to_pixels(window.rem_size()))
+                            .size_range(
+                                rems(7.5).to_pixels(window.rem_size())
+                                    ..rems(16.25).to_pixels(window.rem_size()),
+                            )
                             .child(
                                 div()
                                     .size_full()
@@ -57,8 +62,11 @@ mod tests {
                     )
                     .child(
                         resizable_panel()
-                            .size(px(240.))
-                            .size_range(px(120.)..px(280.))
+                            .size(rems(15.).to_pixels(window.rem_size()))
+                            .size_range(
+                                rems(7.5).to_pixels(window.rem_size())
+                                    ..rems(17.5).to_pixels(window.rem_size()),
+                            )
                             .child(
                                 div()
                                     .size_full()

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,9 +1,9 @@
 //! Select and searchable Combobox presentations over the controlled base roots.
 use crate::{ActiveTheme, ButtonVariant, IconName, button, icon, input};
 use gpui_kit::base::{Combobox, ElementExt as _, Popup, Select, input::InputState};
+use gpui_kit::rems;
 use gpui_kit::{
     App, Context, ElementId, Entity, FocusHandle, Focusable, SharedString, Window, div, prelude::*,
-    px,
 };
 
 #[derive(Clone, Debug)]
@@ -60,7 +60,7 @@ impl ChoiceState {
                         .into_iter()
                         .find(|&i| !this.items[i].disabled)
                 };
-                this.scroll.set_offset(gpui_kit::point(px(0.), px(0.)));
+                this.scroll.set_offset(gpui_kit::Point::default());
                 cx.notify();
             },
         )
@@ -78,7 +78,7 @@ impl ChoiceState {
             query,
             searchable: false,
             scroll: gpui_kit::ScrollHandle::new(),
-            popup_width: px(280.),
+            popup_width: rems(17.5).to_pixels(window.rem_size()),
         }
     }
     pub fn label(mut self, label: impl Into<SharedString>) -> Self {
@@ -308,7 +308,7 @@ fn presentation(
         .border_color(t.control_border())
         .bg(t.normal_fill())
         .child(div().flex_1().min_w_0().text_ellipsis().child(label))
-        .child(icon(IconName::ChevronDown).size(px(14.)))
+        .child(icon(IconName::ChevronDown).size(rems(0.875)))
         .on_click(move |_, window, cx| {
             target.update(cx, |state, cx| state.set_open(!state.open, window, cx))
         });
@@ -332,19 +332,19 @@ fn presentation(
             .id("choice-popup")
             .debug_selector(|| "omarchy-choice-popup".into())
             .track_focus(&focus)
-            .mt(px(4.))
+            .mt(rems(0.25))
             .w(popup_width)
             .max_w(gpui_kit::relative(1.))
-            .p(px(6.))
+            .p(rems(0.375))
             .border_1()
             .border_color(t.control_border())
             .bg(t.background)
             .text_color(t.foreground)
             .font_family(t.font.clone())
-            .text_size(px(12.))
+            .text_size(rems(0.75))
             .flex()
             .flex_col()
-            .gap(px(6.))
+            .gap(rems(0.375))
             .on_mouse_down_out(move |_, window, cx| {
                 close.update(cx, |state, cx| {
                     state.set_open(false, window, cx);
@@ -357,15 +357,15 @@ fn presentation(
         if searchable {
             content = content.child(
                 input("choice-search", &query, window, cx)
-                    .h(px(28.))
-                    .py(px(0.))
-                    .px(px(6.)),
+                    .h(rems(1.75))
+                    .py(rems(0.))
+                    .px(rems(0.375)),
             );
         }
         let mut rows = div()
             .id("choice-options")
             .role(gpui_kit::Role::ListBox)
-            .max_h(px(224.))
+            .max_h(rems(14.))
             .overflow_y_scroll()
             .track_scroll(&scroll)
             .flex()
@@ -373,7 +373,7 @@ fn presentation(
         if visible.is_empty() {
             rows = rows.child(
                 div()
-                    .p(px(10.))
+                    .p(rems(0.625))
                     .text_color(t.secondary)
                     .child("No matching options"),
             );
@@ -385,17 +385,17 @@ fn presentation(
             rows = rows.child(
                 button(("choice-option", index), "", ButtonVariant::Secondary, cx)
                     .accessibility_label(item.label.clone())
-                    .debug_selector(move || format!("omarchy-choice-option-{index}").into())
+                    .debug_selector(move || format!("omarchy-choice-option-{index}"))
                     .role(gpui_kit::Role::ListBoxOption)
                     .aria_selected(selected == Some(index))
                     .when(cursor == Some(index), |row| row.aria_active_descendant())
                     .focusable(false)
                     .disabled(item.disabled)
                     .w_full()
-                    .h(px(28.))
-                    .py(px(0.))
-                    .px(px(6.))
-                    .gap(px(6.))
+                    .h(rems(1.75))
+                    .py(rems(0.))
+                    .px(rems(0.375))
+                    .gap(rems(0.375))
                     .justify_start()
                     .bg(if cursor == Some(index) {
                         t.selected_fill()
@@ -411,10 +411,10 @@ fn presentation(
                     )
                     .child(
                         div()
-                            .w(px(14.))
+                            .w(rems(0.875))
                             .flex_shrink_0()
                             .when(selected == Some(index), |mark| {
-                                mark.child(icon(IconName::Check).size(px(14.)))
+                                mark.child(icon(IconName::Check).size(rems(0.875)))
                             }),
                     )
                     .on_hover(move |hovered, window, cx| {
@@ -513,6 +513,7 @@ fn presentation(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gpui_kit::px;
     use gpui_kit::{Render, TestAppContext, VisualTestContext};
     struct Harness {
         state: Entity<ChoiceState>,
@@ -523,7 +524,7 @@ mod tests {
             crate::focus_scope("root")
                 .size_full()
                 .child(button("before", "Before", ButtonVariant::Secondary, cx))
-                .child(div().w(px(280.)).child(if self.searchable {
+                .child(div().w(rems(17.5)).child(if self.searchable {
                     combobox("choice", &self.state, window, cx).into_any_element()
                 } else {
                     select("choice", &self.state, window, cx).into_any_element()

--- a/src/sheet.rs
+++ b/src/sheet.rs
@@ -1,6 +1,7 @@
 //! Edge-attached modal details, with dismissal and focus trapping owned by base.
 use crate::{ActiveTheme, dialog_backdrop};
-use gpui_kit::{App, Div, FocusHandle, div, prelude::*, px, relative};
+use gpui_kit::rems;
+use gpui_kit::{App, Div, FocusHandle, div, prelude::*, relative};
 
 /// Focus `focus` when opening; restore the trigger in `request_close`.
 pub fn sheet(focus: &FocusHandle, cx: &mut App) -> gpui_kit::base::Sheet {
@@ -17,17 +18,17 @@ pub fn sheet_surface(cx: &App) -> Div {
         .right_0()
         .top_0()
         .h_full()
-        .w(px(360.))
+        .w(rems(22.5))
         .max_w(relative(1.))
         .flex()
         .flex_col()
-        .gap(px(14.))
-        .p(px(18.))
+        .gap(rems(0.875))
+        .p(rems(1.125))
         .border_l_1()
         .border_color(t.border)
         .bg(t.background)
         .font_family(t.font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
         .text_color(t.foreground)
         .occlude()
 }

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -4,8 +4,9 @@ use gpui_kit::base::{
     Slider, SliderIndicator, SliderThumb, SliderTrack,
     slider::{SliderEvent, SliderState, SliderValue},
 };
+use gpui_kit::rems;
 use gpui_kit::{
-    App, Entity, FocusHandle, KeyDownEvent, MouseButton, Window, div, prelude::*, px, relative,
+    App, Entity, FocusHandle, KeyDownEvent, MouseButton, Window, div, prelude::*, relative,
 };
 
 /// Compose themed base parts. Pass disabled here so both track and thumbs are inert.
@@ -26,9 +27,9 @@ pub fn slider(
         .child(
             SliderIndicator::new(state)
                 .absolute()
-                .top(px(12.))
+                .top(rems(0.75))
                 .w_full()
-                .h(px(4.))
+                .h(rems(0.25))
                 .bg(t.border)
                 .child(
                     div()
@@ -61,14 +62,14 @@ pub fn slider(
                 .start(start)
                 .disabled(disabled)
                 .absolute()
-                .top(px(6.))
+                .top(rems(0.375))
                 .left(relative(if start {
                     percentage.start
                 } else {
                     percentage.end
                 }))
-                .ml(px(-8.))
-                .size(px(16.))
+                .ml(rems(-0.5))
+                .size(rems(1.))
                 .border_2()
                 .border_color(t.accent)
                 .bg(t.background)
@@ -114,8 +115,8 @@ pub fn slider(
     Slider::new(state)
         .disabled(disabled)
         .w_full()
-        .h(px(28.))
-        .px(px(8.))
+        .h(rems(1.75))
+        .px(rems(0.5))
         .when(disabled, |s| s.opacity(0.45))
         .child(track)
 }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -1,8 +1,9 @@
 //! Dense, square surfaces and non-interactive information components.
 use crate::ActiveTheme;
 use gpui_kit::base::{Progress, ProgressIndicator, ProgressTrack};
+use gpui_kit::rems;
 use gpui_kit::{
-    App, Div, ElementId, FontWeight, ParentElement, SharedString, Styled, div, px, relative,
+    App, Div, ElementId, FontWeight, ParentElement, SharedString, Styled, div, relative,
 };
 
 pub fn panel(title: impl Into<SharedString>, cx: &App) -> Div {
@@ -11,17 +12,17 @@ pub fn panel(title: impl Into<SharedString>, cx: &App) -> Div {
         .flex()
         .flex_col()
         .min_w_0()
-        .gap(px(14.))
-        .p(px(18.))
+        .gap(rems(0.875))
+        .p(rems(1.125))
         .border_1()
         .border_color(t.border)
         .bg(t.background)
         .font_family(t.font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
         .text_color(t.foreground)
         .child(
             div()
-                .text_size(px(14.))
+                .text_size(rems(0.875))
                 .font_weight(FontWeight::BOLD)
                 .child(title.into()),
         )
@@ -30,7 +31,7 @@ pub fn panel(title: impl Into<SharedString>, cx: &App) -> Div {
 pub fn separator(cx: &App) -> Div {
     div()
         .w_full()
-        .h(px(1.))
+        .h(rems(0.0625))
         .flex_shrink_0()
         .bg(cx.omarchy().divider())
 }
@@ -38,8 +39,8 @@ pub fn separator(cx: &App) -> Div {
 /// A vertical rule for toolbars. Override height to fit a different row size.
 pub fn vertical_separator(cx: &App) -> Div {
     div()
-        .w(px(1.))
-        .h(px(20.))
+        .w(rems(0.0625))
+        .h(rems(1.25))
         .flex_shrink_0()
         .bg(cx.omarchy().divider())
 }
@@ -47,13 +48,13 @@ pub fn vertical_separator(cx: &App) -> Div {
 pub fn keycap(key: impl Into<SharedString>, cx: &App) -> Div {
     let t = cx.omarchy();
     div()
-        .px(px(4.))
-        .py(px(2.))
+        .px(rems(0.25))
+        .py(rems(0.125))
         .border_1()
         .border_color(t.border)
         .bg(t.inset)
         .font_family(t.font.clone())
-        .text_size(px(11.))
+        .text_size(rems(0.6875))
         .font_weight(FontWeight::BOLD)
         .text_color(t.foreground)
         .child(key.into())
@@ -77,13 +78,13 @@ pub fn badge(label: impl Into<SharedString>, status: Status, cx: &App) -> Div {
         Status::Error => t.danger,
     };
     div()
-        .px(px(6.))
-        .py(px(2.))
+        .px(rems(0.375))
+        .py(rems(0.125))
         .border_1()
         .border_color(color)
         .text_color(color)
         .font_family(t.font.clone())
-        .text_size(px(11.))
+        .text_size(rems(0.6875))
         .child(label.into())
 }
 
@@ -96,10 +97,10 @@ pub fn empty_state(
     div()
         .flex()
         .flex_col()
-        .gap(px(8.))
-        .p(px(18.))
+        .gap(rems(0.5))
+        .p(rems(1.125))
         .font_family(t.font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
         .text_color(t.foreground)
         .child(div().font_weight(FontWeight::BOLD).child(title.into()))
         .child(div().text_color(t.secondary).child(description.into()))
@@ -110,12 +111,16 @@ pub fn progress(id: impl Into<ElementId>, value: f32, cx: &App) -> Progress {
     let t = cx.omarchy();
     let value = normalized_progress(value);
     Progress::new(id).value(value).w_full().child(
-        ProgressTrack::new().w_full().h(px(6.)).bg(t.border).child(
-            ProgressIndicator::new()
-                .h_full()
-                .w(relative(value / 100.))
-                .bg(t.accent),
-        ),
+        ProgressTrack::new()
+            .w_full()
+            .h(rems(0.375))
+            .bg(t.border)
+            .child(
+                ProgressIndicator::new()
+                    .h_full()
+                    .w(relative(value / 100.))
+                    .bg(t.accent),
+            ),
     )
 }
 
@@ -125,6 +130,56 @@ fn normalized_progress(value: f32) -> f32 {
     } else {
         0.
     }
+}
+
+/// Notification surface; compose actions and use gpui-base's ToastManager for
+/// application-owned stacking and timeout policy.
+pub fn toast(id: impl Into<gpui_kit::ElementId>, cx: &App) -> gpui_kit::base::Toast {
+    let t = cx.omarchy();
+    gpui_kit::base::Toast::new(id)
+        .flex()
+        .flex_col()
+        .gap(rems(0.625))
+        .p(rems(0.875))
+        .w_full()
+        .border_1()
+        .rounded_none()
+        .border_color(t.border)
+        .bg(t.background)
+        .text_color(t.foreground)
+        .font_family(t.font.clone())
+        .text_size(rems(0.75))
+}
+
+/// A square identity marker. Supply initials or an icon in the fallback slot;
+/// callers can replace it with `avatar_image` through the base image builder.
+pub fn avatar(initials: impl Into<SharedString>, cx: &App) -> gpui_kit::base::Avatar {
+    let t = cx.omarchy();
+    gpui_kit::base::Avatar::new()
+        .size(rems(2.))
+        .flex_shrink_0()
+        .overflow_hidden()
+        .rounded_none()
+        .border_1()
+        .border_color(t.control_border())
+        .bg(t.hover_fill())
+        .font_family(t.font.clone())
+        .text_size(rems(0.75))
+        .text_color(t.foreground)
+        .fallback(
+            gpui_kit::base::AvatarFallback::new()
+                .size_full()
+                .flex()
+                .items_center()
+                .justify_center()
+                .child(initials.into()),
+        )
+}
+
+/// An image slot sized to its avatar. Image loading and failure policy remain
+/// with the application, matching gpui-base's explicit slot API.
+pub fn avatar_image(source: impl Into<gpui_kit::ImageSource>) -> gpui_kit::base::AvatarImage {
+    gpui_kit::base::AvatarImage::new(source).size_full()
 }
 
 #[cfg(test)]
@@ -142,54 +197,4 @@ mod tests {
             assert_eq!(normalized_progress(input), expected);
         }
     }
-}
-
-/// Notification surface; compose actions and use gpui-base's ToastManager for
-/// application-owned stacking and timeout policy.
-pub fn toast(id: impl Into<gpui_kit::ElementId>, cx: &App) -> gpui_kit::base::Toast {
-    let t = cx.omarchy();
-    gpui_kit::base::Toast::new(id)
-        .flex()
-        .flex_col()
-        .gap(px(10.))
-        .p(px(14.))
-        .w_full()
-        .border_1()
-        .rounded(px(0.))
-        .border_color(t.border)
-        .bg(t.background)
-        .text_color(t.foreground)
-        .font_family(t.font.clone())
-        .text_size(px(12.))
-}
-
-/// A square identity marker. Supply initials or an icon in the fallback slot;
-/// callers can replace it with `avatar_image` through the base image builder.
-pub fn avatar(initials: impl Into<SharedString>, cx: &App) -> gpui_kit::base::Avatar {
-    let t = cx.omarchy();
-    gpui_kit::base::Avatar::new()
-        .size(px(32.))
-        .flex_shrink_0()
-        .overflow_hidden()
-        .rounded(px(0.))
-        .border_1()
-        .border_color(t.control_border())
-        .bg(t.hover_fill())
-        .font_family(t.font.clone())
-        .text_size(px(12.))
-        .text_color(t.foreground)
-        .fallback(
-            gpui_kit::base::AvatarFallback::new()
-                .size_full()
-                .flex()
-                .items_center()
-                .justify_center()
-                .child(initials.into()),
-        )
-}
-
-/// An image slot sized to its avatar. Image loading and failure policy remain
-/// with the application, matching gpui-base's explicit slot API.
-pub fn avatar_image(source: impl Into<gpui_kit::ImageSource>) -> gpui_kit::base::AvatarImage {
-    gpui_kit::base::AvatarImage::new(source).size_full()
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,9 +1,8 @@
 //! Primitive tables: application-owned columns, rows and content.
 use crate::ActiveTheme;
 use gpui_kit::base::{Table, TableCell, TableHead, TableRow};
-use gpui_kit::{
-    App, ElementId, FontWeight, InteractiveElement, Styled, prelude::FluentBuilder, px,
-};
+use gpui_kit::rems;
+use gpui_kit::{App, ElementId, FontWeight, InteractiveElement, Styled, prelude::FluentBuilder};
 
 pub fn table(id: impl Into<ElementId>, cx: &App) -> Table {
     let t = cx.omarchy();
@@ -13,7 +12,7 @@ pub fn table(id: impl Into<ElementId>, cx: &App) -> Table {
         .border_color(t.border)
         .text_color(t.foreground)
         .font_family(t.font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
 }
 
 /// `index` is the one-based accessibility row index, including the header.
@@ -22,7 +21,7 @@ pub fn table_row(id: impl Into<ElementId>, index: usize, cx: &App) -> TableRow {
     let t = cx.omarchy();
     TableRow::new(id, index)
         .flex()
-        .min_h(px(28.))
+        .min_h(rems(1.75))
         .when(index > 1, |row| row.border_t_1())
         .border_color(t.border)
         .hover(|s| s.bg(t.surface))
@@ -34,8 +33,8 @@ pub fn table_head(id: impl Into<ElementId>, index: usize, cx: &App) -> TableHead
     TableHead::new(id, index)
         .flex_1()
         .min_w_0()
-        .px(px(8.))
-        .py(px(6.))
+        .px(rems(0.5))
+        .py(rems(0.375))
         .bg(t.surface)
         .text_color(t.bright)
         .font_weight(FontWeight::BOLD)
@@ -45,6 +44,6 @@ pub fn table_cell(id: impl Into<ElementId>, index: usize, _cx: &App) -> TableCel
     TableCell::new(id, index)
         .flex_1()
         .min_w_0()
-        .px(px(8.))
-        .py(px(6.))
+        .px(rems(0.5))
+        .py(rems(0.375))
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,10 +1,10 @@
 //! Read-only rich text using base's Markdown and HTML renderers.
 use crate::ActiveTheme;
 use gpui_kit::base::{TextView, TextViewStyle};
-use gpui_kit::{App, ElementId, SharedString, StyleRefinement, Styled, px, rems};
+use gpui_kit::{App, ElementId, SharedString, StyleRefinement, Styled, Window, rems};
 
 /// Theme mapping shared by Markdown, HTML and state-backed TextViews.
-pub fn text_view_style(cx: &App) -> TextViewStyle {
+pub fn text_view_style(window: &Window, cx: &App) -> TextViewStyle {
     let t = cx.omarchy();
     TextViewStyle::from_theme(&gpui_kit::base::Theme::global(cx))
         .with_foreground(t.foreground)
@@ -18,58 +18,71 @@ pub fn text_view_style(cx: &App) -> TextViewStyle {
             ..Default::default()
         })
         .with_paragraph_gap(rems(0.75))
-        .with_heading_base_font_size(px(12.))
-        .with_heading_font_size(|level, _| {
-            px(match level {
-                1 => 20.,
-                2 => 16.,
-                3 => 14.,
-                _ => 12.,
-            })
+        .with_heading_base_font_size(rems(0.75).to_pixels(window.rem_size()))
+        .with_heading_font_size(|level, base| {
+            base * match level {
+                1 => 5. / 3.,
+                2 => 4. / 3.,
+                3 => 7. / 6.,
+                _ => 1.,
+            }
         })
-        .with_code_block(StyleRefinement::default().p(px(10.)).rounded(px(0.)))
+        .with_code_block(StyleRefinement::default().p(rems(0.625)).rounded_none())
 }
 
-pub fn markdown(id: impl Into<ElementId>, source: impl Into<SharedString>, cx: &App) -> TextView {
+pub fn markdown(
+    id: impl Into<ElementId>,
+    source: impl Into<SharedString>,
+    window: &Window,
+    cx: &App,
+) -> TextView {
     TextView::markdown(id, source)
-        .style(text_view_style(cx))
+        .style(text_view_style(window, cx))
         .font_family(cx.omarchy().font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
         .selectable(true)
 }
 
-pub fn html(id: impl Into<ElementId>, source: impl Into<SharedString>, cx: &App) -> TextView {
+pub fn html(
+    id: impl Into<ElementId>,
+    source: impl Into<SharedString>,
+    window: &Window,
+    cx: &App,
+) -> TextView {
     TextView::html(id, source)
-        .style(text_view_style(cx))
+        .style(text_view_style(window, cx))
         .font_family(cx.omarchy().font.clone())
-        .text_size(px(12.))
+        .text_size(rems(0.75))
         .selectable(true)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gpui_kit::px;
     use gpui_kit::{Context, IntoElement, Render, TestAppContext, Window, div, point, prelude::*};
 
     struct Document {
         html: bool,
     }
     impl Render for Document {
-        fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
             let text = if self.html {
                 html(
                     "document",
                     "<p><a href=\"https://github.com/huacnlee/gpui-omarchy/issues\">Project source</a></p>",
+                    window,
                     cx,
                 )
             } else {
                 markdown(
                     "document",
                     "[Project source](https://github.com/huacnlee/gpui-omarchy)",
+                    window,
                     cx,
                 )
             };
-            div().w(px(320.)).child(text)
+            div().w(rems(20.)).child(text)
         }
     }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,6 +1,10 @@
 //! Semantic palette and its projection into gpui-base.
 use gpui_kit::base::{ColorTokens, RadiusTokens, ThemeAppearance};
-use gpui_kit::{App, Global, Hsla, SharedString, px, rgb};
+use gpui_kit::{App, Global, Hsla, Pixels, SharedString, px, rems, rgb};
+
+// gpui-base 0.6 stores global typography tokens in pixels. This is the nominal
+// 100% snapshot only; Omarchy layout uses rems resolved by each window.
+const BASE_REM_SIZE: Pixels = px(16.);
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Theme {
@@ -139,26 +143,26 @@ impl Theme {
         base.appearance = self.appearance;
         base.tokens.colors = self.tokens();
         base.tokens.radius = RadiusTokens {
-            none: px(0.),
-            sm: px(0.),
-            md: px(0.),
-            lg: px(0.),
-            xl: px(0.),
-            full: px(0.),
+            none: Pixels::ZERO,
+            sm: Pixels::ZERO,
+            md: Pixels::ZERO,
+            lg: Pixels::ZERO,
+            xl: Pixels::ZERO,
+            full: Pixels::ZERO,
         };
         let type_scale = &mut base.tokens.typography;
         type_scale.sans = self.font.clone();
         type_scale.mono = self.font.clone();
         for (token, size) in [
-            (&mut type_scale.xs, 10.),
-            (&mut type_scale.sm, 11.),
-            (&mut type_scale.md, 12.),
-            (&mut type_scale.lg, 14.),
-            (&mut type_scale.xl, 16.),
-            (&mut type_scale.mono_md, 12.),
+            (&mut type_scale.xs, 0.625),
+            (&mut type_scale.sm, 0.6875),
+            (&mut type_scale.md, 0.75),
+            (&mut type_scale.lg, 0.875),
+            (&mut type_scale.xl, 1.),
+            (&mut type_scale.mono_md, 0.75),
         ] {
-            token.size = px(size);
-            token.line_height = px(size * 1.5);
+            token.size = rems(size).to_pixels(BASE_REM_SIZE);
+            token.line_height = token.size * 1.5;
         }
         cx.set_global(self);
         cx.refresh_windows();

--- a/src/tooltip.rs
+++ b/src/tooltip.rs
@@ -1,8 +1,8 @@
 //! Short, non-interactive explanations with GPUI's tooltip lifecycle.
 use crate::ActiveTheme;
+use gpui_kit::rems;
 use gpui_kit::{
     App, AppContext, Context, Render, SharedString, StatefulInteractiveElement, Window, prelude::*,
-    px,
 };
 use std::time::Duration;
 
@@ -10,16 +10,16 @@ use std::time::Duration;
 pub fn tooltip(text: impl Into<SharedString>, cx: &App) -> gpui_kit::base::Tooltip {
     let t = cx.omarchy();
     gpui_kit::base::Tooltip::new("omarchy-tooltip")
-        .max_w(px(320.))
-        .px(px(10.))
-        .py(px(6.))
+        .max_w(rems(20.))
+        .px(rems(0.625))
+        .py(rems(0.375))
         .border_1()
-        .rounded(px(0.))
+        .rounded_none()
         .border_color(t.control_border())
         .bg(t.background)
         .text_color(t.foreground)
         .font_family(t.font.clone())
-        .text_size(px(11.))
+        .text_size(rems(0.6875))
         .child(text.into())
 }
 
@@ -45,6 +45,7 @@ impl Render for TooltipText {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gpui_kit::px;
     use gpui_kit::{Render, TestAppContext, point};
     struct Harness;
     impl Render for Harness {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,12 +1,13 @@
 use crate::{ActiveTheme, IconName, icon};
 use gpui_kit::base::{Tree, TreeState};
-use gpui_kit::{App, Entity, div, prelude::*, px};
+use gpui_kit::rems;
+use gpui_kit::{App, Entity, div, prelude::*};
 
 /// Virtualized, keyboard-navigable tree with application-owned base state.
 pub fn tree(state: &Entity<TreeState>, cx: &App) -> Tree {
     let t = cx.omarchy().clone();
     Tree::new(state)
-        .h(px(280.))
+        .h(rems(17.5))
         .w_full()
         .list_style(div().size_full().style().clone())
         .item(move |_, entry, state, _, _| {
@@ -15,12 +16,12 @@ pub fn tree(state: &Entity<TreeState>, cx: &App) -> Tree {
                 .debug_selector(move || format!("omarchy-tree-{id}"))
                 .flex()
                 .items_center()
-                .gap(px(6.))
-                .h(px(28.))
-                .pl(px(6. + entry.depth() as f32 * 20.))
-                .pr(px(8.))
+                .gap(rems(0.375))
+                .h(rems(1.75))
+                .pl(rems(0.375 + entry.depth() as f32 * 1.25))
+                .pr(rems(0.5))
                 .font_family(t.font.clone())
-                .text_size(px(12.))
+                .text_size(rems(0.75))
                 .text_color(t.foreground)
                 .bg(if state.is_selected() {
                     t.selected_fill()
@@ -38,7 +39,7 @@ pub fn tree(state: &Entity<TreeState>, cx: &App) -> Tree {
                         } else {
                             IconName::ChevronRight
                         })
-                        .size(px(14.))
+                        .size(rems(0.875))
                         .flex_shrink_0(),
                     )
                 })

--- a/tests/interaction.rs
+++ b/tests/interaction.rs
@@ -1,3 +1,4 @@
+use gpui_kit::rems;
 use gpui_kit::{
     Context, IntoElement, Modifiers, Render, TestAppContext, Window, div, point, prelude::*, px,
 };
@@ -11,9 +12,9 @@ struct Harness {
 impl Render for Harness {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let clicks = self.clicks.clone();
-        div().id("root").tab_group().size(px(200.)).child(
+        div().id("root").tab_group().size(rems(12.5)).child(
             button("apply", "Apply", ButtonVariant::Primary, cx)
-                .w(px(120.))
+                .w(rems(7.5))
                 .disabled(self.disabled)
                 .on_click(move |_, _, _| clicks.set(clicks.get() + 1)),
         )
@@ -113,7 +114,7 @@ struct MenuHarness(Rc<Cell<usize>>);
 impl Render for MenuHarness {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let selected = self.0.clone();
-        div().size(px(300.)).child(menu(
+        div().size(rems(18.75)).child(menu(
             "actions",
             button("trigger", "Actions", ButtonVariant::Secondary, cx),
             vec![

--- a/website/public/gallery/index.html
+++ b/website/public/gallery/index.html
@@ -8,7 +8,7 @@
   <meta name="description" content="Interactive GPUI Omarchy component gallery, rendered from Rust with WebAssembly and WebGPU.">
   <meta name="robots" content="noindex, follow">
   <style>
-    *{box-sizing:border-box}html,body{width:100%;height:100%;margin:0;background:#1a1b26;color:#a9b1d6;font:14px/1.6 system-ui}body{overflow:hidden}body>canvas{position:fixed;inset:0;display:block;width:100%;height:100%}#loading{position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;padding:24px;text-align:center}#loading p{margin:0;max-width:460px}button{font:inherit;color:inherit;background:transparent;border:1px solid currentColor;padding:6px 12px;cursor:pointer}button:focus-visible{outline:2px solid #7aa2f7;outline-offset:2px}
+    *{box-sizing:border-box}html,body{width:100%;height:100%;margin:0;background:#1a1b26;color:#a9b1d6;font-family:system-ui;line-height:1.6}body{overflow:hidden;font-size:0.875rem}body>canvas{position:fixed;inset:0;display:block;width:100%;height:100%}#loading{position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:0.75rem;padding:1.5rem;text-align:center}#loading p{margin:0;max-width:28.75rem}button{font:inherit;color:inherit;background:transparent;border:1px solid currentColor;padding:0.375rem 0.75rem;cursor:pointer}button:focus-visible{outline:2px solid #7aa2f7;outline-offset:2px}
   </style>
 </head>
 <body>

--- a/website/src/components/ThemeMenu.css
+++ b/website/src/components/ThemeMenu.css
@@ -3,14 +3,14 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  padding: 6px 10px;
+  gap: 0.5rem;
+  padding: 0.375rem 0.625rem;
   border: 1px solid var(--border);
   border-radius: 0;
   background: var(--surface);
   color: var(--foreground);
   font: inherit;
-  font-size: 12px;
+  font-size: 0.75rem;
   line-height: 1.5;
   cursor: pointer;
   touch-action: manipulation;
@@ -26,9 +26,9 @@
 .theme-menu-positioner { z-index: 200; }
 .theme-menu-popup {
   box-sizing: border-box;
-  width: 224px;
-  max-width: calc(100vw - 32px);
-  padding: 6px;
+  width: 14rem;
+  max-width: calc(100vw - 2rem);
+  padding: 0.375rem;
   border: 1px solid var(--border);
   border-radius: 0;
   background: var(--background);
@@ -36,16 +36,16 @@
   font-family: inherit;
   outline: none;
 }
-.theme-menu-label { padding: 8px 10px; color: var(--muted); font-size: 11px; }
+.theme-menu-label { padding: 0.5rem 0.625rem; color: var(--muted); font-size: 0.6875rem; }
 .theme-menu-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  min-height: 36px;
-  padding: 6px 10px;
+  gap: 1rem;
+  min-height: 2.25rem;
+  padding: 0.375rem 0.625rem;
   box-sizing: border-box;
-  font-size: 13px;
+  font-size: 0.8125rem;
   line-height: 1.5;
   cursor: pointer;
   outline: none;
@@ -53,15 +53,15 @@
 }
 .theme-menu-item[data-highlighted] { background: var(--hover); }
 .theme-menu-item:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-.theme-menu-check { display: flex; align-items: center; margin-left: auto; width: 16px; height: 16px; flex-shrink: 0; }
+.theme-menu-check { display: flex; align-items: center; margin-left: auto; width: 1rem; height: 1rem; flex-shrink: 0; }
 .copy-control { display: inline-flex; }
-.copy-button { min-width: 66px; white-space: nowrap; }
+.copy-button { min-width: 4.125rem; white-space: nowrap; }
 .control-status {
   position: absolute;
-  width: 1px;
-  height: 1px;
+  width: 0.0625rem;
+  height: 0.0625rem;
   padding: 0;
-  margin: -1px;
+  margin: -0.0625rem;
   overflow: hidden;
   clip-path: inset(50%);
   white-space: nowrap;

--- a/website/src/pages/guides.md
+++ b/website/src/pages/guides.md
@@ -328,7 +328,7 @@ with_tooltip(
 )
 ```
 
-`icon(name: IconName) -> icon::Icon` returns a 16px, non-shrinking icon; use `Styled` to change size or text color. `Icon` implements `RenderOnce` and `IntoElement`. Icons inherit text color at render time and embed their assets, so you do not need to replace your application's `AssetSource`.
+`icon(name: IconName) -> icon::Icon` returns a 1rem, non-shrinking icon; use `Styled` to change size or text color. `Icon` implements `RenderOnce` and `IntoElement`. Icons inherit text color at render time and embed their assets, so you do not need to replace your application's `AssetSource`.
 
 `IconName` has these variants: `Check`, `Minus`, `Plus`, `ChevronDown`, `ChevronRight`, `ChevronLeft`, `Calendar`, `Star`, `ExternalLink`, `Close`, `Search`, `Menu`, `Settings` and `TriangleAlert`. `IconName::path(self) -> &'static str` returns the bundled `icons/*.svg` asset key, not a URL to fetch. `IconName` is re-exported at the crate root; the concrete icon type is `gpui_omarchy::icon::Icon`.
 
@@ -368,11 +368,11 @@ panel("Workspace settings", cx)
 
 | Constructor | State, context and result |
 | --- | --- |
-| `input(id, &state, window, cx)` | `Entity<gpui_kit::base::input::InputState>`, `&Window`, `&mut App`; returns `gpui_kit::base::InputBase`. |
+| `input(id, &state, window, cx)` | `Entity<gpui_kit::base::input::InputState>`, `&Window`, `&mut App`; returns `gpui_omarchy::Input`. |
 | `textarea(id, &state, window, cx)` | `Entity<gpui_kit::base::input::TextareaState>`, `&Window`, `&mut App`; returns `gpui_kit::base::InputBase`. |
 | `number_input(&state, cx)` | `Entity<InputState>`, `&mut App`; returns `gpui_kit::base::NumberInput`. |
 
-The returned `InputBase` is the styled frame containing the editor. Configure values, placeholders and editor behavior on the state. Constructors refresh the state's editor style and focus styling. Number input centers the text and adds decrement/increment controls with base arrow-key stepping; configure numeric constraints through the base number-input API. Input validation and saving remain application responsibilities.
+Configure values, placeholders and editor behavior on the state. Constructors refresh the state's editor style and focus styling. Single-line `Input` supports `.prefix(element)` and `.suffix(element)` for text, icons or custom content inside the shared border. Both slots are empty by default and remain outside the editable value. The editor takes the remaining width. For example, `input("price", &self.price, window, cx).prefix("$").suffix("USD")`. Textarea returns the base styled frame. Number input centers the text and adds decrement/increment controls with base arrow-key stepping; configure numeric constraints through the base number-input API. Input validation and saving remain application responsibilities.
 
 ### Toggle values
 
@@ -478,6 +478,7 @@ tab_list(
     "workspace-pages",
     vec![ChoiceItem::new("files", "Files"), ChoiceItem::new("activity", "Activity")],
     Some(self.page),
+    false, // show_shortcuts: optional one-based number hints
     move |index, window, cx| changed(&index, window, cx),
     window,
     cx,
@@ -485,6 +486,8 @@ tab_list(
 ```
 
 Each group has one Tab stop. Left/Right or h/l moves the keyboard cursor; Enter or Space commits. Moving the cursor alone does not switch the selected value. Disabled choices are skipped, and activating the current selection does not emit a change.
+
+Tabs use a square segmented strip. Set `show_shortcuts` to `true` to render automatic 1-based number hints; bind the corresponding shortcuts in your application. `button_group` uses equal-width segments filling its container for form choices such as Limit / Market.
 
 For custom compositions, use `tabs(id, cx) -> gpui_kit::base::Tabs` and `tab(id, label, selected: bool, cx) -> gpui_kit::base::Tab`. Both take `&App`. You own selected state, callbacks and composition; the low-level pair does not add `tab_list`'s option-group cursor handling.
 
@@ -634,7 +637,7 @@ popover(
 
 `popover<E>(id, trigger, content) -> gpui_kit::base::Popover` requires `E: IntoElement`, the same selectable trigger bounds as `menu`, and a content builder `FnOnce(&mut gpui_kit::base::PopoverState, &mut Window, &mut Context<gpui_kit::base::PopoverState>) -> E + 'static`.
 
-The content builder runs in the popup state's context, not your parent view's context. Move entity handles or a parent listener into it when content needs to update your view. The constructor wraps content in `popover_surface(cx) -> Div`, a square, 280px-wide themed surface; use that helper directly when composing another popup. Popover content has its own keyboard context so editing does not activate the trigger. Escape dismisses and restores focus.
+The content builder runs in the popup state's context, not your parent view's context. Move entity handles or a parent listener into it when content needs to update your view. The constructor wraps content in `popover_surface(cx) -> Div`, a square, 17.5rem-wide themed surface; use that helper directly when composing another popup. Popover content has its own keyboard context so editing does not activate the trigger. Escape dismisses and restores focus.
 
 ### Add supplementary help
 
@@ -684,7 +687,7 @@ The footer dispatches base confirm and cancel actions. Base owns the focus trap,
 | Constructor | What it supplies |
 | --- | --- |
 | `dialog_backdrop() -> gpui_kit::base::DialogBackdrop` | Full-size black scrim at 60% opacity; useful when composing a custom host. |
-| `dialog_popup(cx: &App) -> gpui_kit::base::DialogPopup` | Square content surface, 420px wide and capped at its available width. |
+| `dialog_popup(cx: &App) -> gpui_kit::base::DialogPopup` | Square content surface, 26.25rem wide and capped at its available width. |
 | `dialog_title(title, cx: &App) -> gpui_kit::base::DialogTitle` | Emphasized title slot. |
 | `dialog_description(text, cx: &App) -> gpui_kit::base::DialogDescription` | Secondary descriptive text slot. |
 | `dialog_button(id, label, ButtonVariant, cx: &App) -> Button` | Outlined footer action using the requested semantic variant. |
@@ -704,7 +707,7 @@ sheet(&self.sheet_focus, cx)
     .request_close(move |window, cx| close(&(), window, cx))
 ```
 
-The default surface is 360px wide, capped at the available width, anchored to the right edge and full height. Refine its width with normal `Styled` builders. Focus `self.sheet_focus` in your opening callback; Escape and backdrop dismissal request closing, while your application updates visibility and restores focus.
+The default surface is 22.5rem wide, capped at the available width, anchored to the right edge and full height. Refine its width with normal `Styled` builders. Focus `self.sheet_focus` in your opening callback; Escape and backdrop dismissal request closing, while your application updates visibility and restores focus.
 
 ## Present status and rich content
 
@@ -721,7 +724,7 @@ panel("Import", cx)
 | --- | --- |
 | `panel(title, cx)` | `Div`: title and vertically arranged content with padding and an outer edge. |
 | `separator(cx)` | `Div`: a one-pixel horizontal divider. |
-| `vertical_separator(cx)` | `Div`: a one-pixel-wide, 20px-high toolbar divider; override height when needed. |
+| `vertical_separator(cx)` | `Div`: a thin, 1.25rem-high toolbar divider; override height when needed. |
 | `keycap(key, cx)` | `Div`: a bordered keyboard hint. It does not bind that key. |
 | `badge(label, status: Status, cx)` | `Div`: short status label with a matching border. |
 | `empty_state(title, description, cx)` | `Div`: explain what belongs in the empty region; add a relevant action as a child. |
@@ -747,10 +750,10 @@ The application decides whether to provide the image or fall back to initials af
 
 ### Render a document
 
-`markdown(id, source, cx)` and `html(id, source, cx)` both return `gpui_kit::base::TextView`. They accept `id: impl Into<ElementId>`, `source: impl Into<SharedString>` and `cx: &App`.
+`markdown(id, source, window, cx)` and `html(id, source, window, cx)` both return `gpui_kit::base::TextView`. They accept `id: impl Into<ElementId>`, `source: impl Into<SharedString>`, `window: &Window` and `cx: &App`. The window supplies the current rem scale for heading sizes.
 
 ```rust
-markdown("readme", "# Workspace\n\nSelect a file to begin.", cx)
+markdown("readme", "# Workspace\n\nSelect a file to begin.", window, cx)
 ```
 
 These are read-only rich-text views with document typography, links and selectable content, not source editors or embedded web browsers. Install one `gpui_kit::base::TextSelectionLayer` as the root's **first child** so selection is initialized before rendering text:
@@ -759,12 +762,12 @@ These are read-only rich-text views with document typography, links and selectab
 focus_scope("document")
     .size_full()
     .child(gpui_kit::base::TextSelectionLayer)
-    .child(markdown("readme", "# Workspace\n\nSelect a file to begin.", cx))
+    .child(markdown("readme", "# Workspace\n\nSelect a file to begin.", window, cx))
 ```
 
 Do not add a separate selection layer to every text view.
 
-For a state-backed base TextView, use `text_view_style(cx: &App) -> gpui_kit::base::TextViewStyle`. It maps Omarchy foreground, muted text, links, selection, borders and code surfaces into the base renderer's style, so all three entry points share the same document presentation.
+For a state-backed base TextView, use `text_view_style(window: &Window, cx: &App) -> gpui_kit::base::TextViewStyle`. It maps Omarchy foreground, muted text, links, selection, borders and code surfaces into the base renderer's style, so all three entry points share the same document presentation.
 
 ## Display tables, lists and trees
 
@@ -792,7 +795,7 @@ Cells share available width by default; refine widths consistently across the he
 
 ```rust
 let sizes = std::rc::Rc::new(vec![
-    gpui_kit::size(gpui_kit::px(0.), gpui_kit::px(28.));
+    gpui_kit::size(gpui_kit::Pixels::ZERO, gpui_kit::rems(1.75).to_pixels(window.rem_size()));
     self.records.len()
 ]);
 virtual_list(
@@ -802,7 +805,7 @@ virtual_list(
     |this, range, _, _| {
         range.map(|index| {
             gpui_kit::div()
-                .h(gpui_kit::px(28.))
+                .h(gpui_kit::rems(1.75))
                 .child(this.records[index].clone())
         }).collect()
     },
@@ -812,11 +815,11 @@ virtual_list(
 
 The full parameter types are `view: Entity<V>`, `id: impl Into<ElementId>`, `sizes: Rc<Vec<Size<Pixels>>>`, `render: impl Fn(&mut V, Range<usize>, &mut Window, &mut Context<V>) -> Vec<R> + 'static`, and `cx: &App`, where `V: Render` and `R: IntoElement`.
 
-Every size must match its row's rendered height, including variable-height rows. The default list height is 280px; override it for your layout. Retain a base `VirtualListScrollHandle` and attach it with `.track_scroll(&handle)` to preserve position or navigate to an item.
+Every size must match its row's rendered height, including variable-height rows. Resolve row sizes using `window.rem_size()` and rebuild cached measurements when it changes. The default list height is 17.5rem; override it for your layout. Retain a base `VirtualListScrollHandle` and attach it with `.track_scroll(&handle)` to preserve position or navigate to an item.
 
 ### Add a scrollbar
 
-`scrollbar(id, axis, &handle, cx) -> gpui_kit::base::Scrollbar` accepts `axis: gpui_kit::base::ScrollbarAxis`, `cx: &App` and a handle implementing `gpui_kit::base::ScrollbarHandle + Clone`. Vertical, horizontal and both-axis modes are supported.
+`scrollbar(id, axis, &handle, window, cx) -> gpui_kit::base::Scrollbar` accepts `axis: gpui_kit::base::ScrollbarAxis`, `window: &Window`, `cx: &App` and a handle implementing `gpui_kit::base::ScrollbarHandle + Clone`. Vertical, horizontal and both-axis modes are supported.
 
 Share the handle with the scrollable content, and render the scrollbar **after** that content inside the same relative container. The default mode is `ScrollbarMode::Always`; base builders remain available for customization. A scrollbar does not make ordinary content scrollable by itself.
 
@@ -835,7 +838,7 @@ let files = cx.new(|cx| {
 });
 ```
 
-`tree(&Entity<gpui_kit::base::TreeState>, cx: &App) -> gpui_kit::base::Tree` adds indented 28px rows, expand/collapse icons, disabled styling and selected fills to the base virtualized keyboard tree. It defaults to 280px high. Read selection and update items through the base state, and observe the entity when dependent content needs to redraw.
+`tree(&Entity<gpui_kit::base::TreeState>, cx: &App) -> gpui_kit::base::Tree` adds indented 1.75rem rows, expand/collapse icons, disabled styling and selected fills to the base virtualized keyboard tree. It defaults to 17.5rem high. Read selection and update items through the base state, and observe the entity when dependent content needs to redraw.
 
 ## Arrange a workspace
 

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -17,51 +17,51 @@
   --hover:#e6e4d9; --selected:#dad8ce; --selection:#d0d9e4;
 }
 
-@theme inline { --color-canvas:var(--background); --color-ink:var(--foreground); --color-quiet:var(--muted); --color-brand:var(--accent); --color-line:var(--border); --font-mono:'JetBrains Mono Variable',monospace; --font-sans:'Geist Variable',sans-serif; --radius-sm:0px; --radius-md:0px; --radius-lg:0px; }
+@theme inline { --color-canvas:var(--background); --color-ink:var(--foreground); --color-quiet:var(--muted); --color-brand:var(--accent); --color-line:var(--border); --font-mono:'JetBrains Mono Variable',monospace; --font-sans:'Geist Variable',sans-serif; --radius-sm:0; --radius-md:0; --radius-lg:0; }
 * { box-sizing:border-box; }
 html { font-family:var(--font-mono); font-synthesis:none; scroll-behavior:smooth; background:var(--background); color:var(--foreground); }
-body { margin:0; font-size:15px; line-height:1.7; }
+body { margin:0; font-size:0.9375rem; line-height:1.7; }
 h1,h2,h3,h4 { font-family:var(--font-sans); font-weight:600; line-height:1.2; letter-spacing:-.025em; text-wrap:balance; }
-h1 { font-size:clamp(27px,3vw,36px); } h2 { font-size:28px; } h3 { font-size:20px; }
+h1 { font-size:clamp(1.6875rem,3vw,2.25rem); } h2 { font-size:1.75rem; } h3 { font-size:1.25rem; }
 p { text-wrap:pretty; } a,button,input { -webkit-tap-highlight-color:transparent; touch-action:manipulation; }
 a { color:inherit; } button,input,select { font:inherit; } button { cursor:pointer; } button:disabled { cursor:default; opacity:.5; }
 ::selection { background:var(--selection); color:var(--bright); }
 :focus-visible { outline:2px solid var(--accent); outline-offset:4px; }
-[id] { scroll-margin-top:90px; }
-.shell { width:min(100% - 48px,1104px); margin-inline:auto; }
-.site-header { height:68px; border-bottom:1px solid var(--subtle); background:var(--background); position:sticky; top:0; z-index:100; }
-.site-header .shell { height:100%; display:flex; align-items:center; justify-content:space-between; gap:20px; }
-.site-name { display:inline-flex; align-items:center; justify-content:center; min-width:44px; min-height:44px; text-decoration:none; }
-.site-logo { display:block; width:24px; height:24px; flex-shrink:0; background:var(--accent); mask:var(--site-logo-url) no-repeat center / contain; }
-.site-nav { display:flex; align-items:center; gap:28px; font-size:13px; }
+[id] { scroll-margin-top:5.625rem; }
+.shell { width:min(100% - 3rem,69rem); margin-inline:auto; }
+.site-header { height:4.25rem; border-bottom:1px solid var(--subtle); background:var(--background); position:sticky; top:0; z-index:100; }
+.site-header .shell { height:100%; display:flex; align-items:center; justify-content:space-between; gap:1.25rem; }
+.site-name { display:inline-flex; align-items:center; justify-content:center; min-width:2.75rem; min-height:2.75rem; text-decoration:none; }
+.site-logo { display:block; width:1.5rem; height:1.5rem; flex-shrink:0; background:var(--accent); mask:var(--site-logo-url) no-repeat center / contain; }
+.site-nav { display:flex; align-items:center; gap:1.75rem; font-size:0.8125rem; }
 .site-nav>a { text-decoration:none; color:var(--muted); } .site-nav>a:hover { color:var(--foreground); }
-.hero { padding:64px 0 48px; text-align:center; container-type:inline-size; --pxc:calc(min((100cqw - 48px) * .88,896px) / 81); }
-.hero-brand { display:flex; align-items:center; justify-content:center; gap:24px; margin-bottom:28px; color:var(--accent); }
-.hero-gpui { font-size:16px; letter-spacing:.18em; }
-.wordmark { display:block; width:calc(var(--pxc) * 29); max-width:324px; min-width:180px; aspect-ratio:4131/950; background:currentColor; mask:var(--wordmark-url) no-repeat center/contain; }
-.hero h1 { margin:0 0 20px; } .hero .lead { max-width:680px; margin:0 auto; color:var(--muted); line-height:1.8; }
-.actions { display:flex; flex-wrap:wrap; gap:12px; align-items:center; }
-.hero .actions { justify-content:center; margin-top:28px; }
-.button { display:inline-flex; align-items:center; justify-content:center; min-height:42px; padding:8px 16px; border:1px solid var(--border); background:var(--surface); text-decoration:none; font-size:14px; transition:background 150ms ease-out; }
+.hero { padding:4rem 0 3rem; text-align:center; container-type:inline-size; --pxc:calc(min((100cqw - 3rem) * .88,56rem) / 81); }
+.hero-brand { display:flex; align-items:center; justify-content:center; gap:1.5rem; margin-bottom:1.75rem; color:var(--accent); }
+.hero-gpui { font-size:1rem; letter-spacing:.18em; }
+.wordmark { display:block; width:calc(var(--pxc) * 29); max-width:20.25rem; min-width:11.25rem; aspect-ratio:4131/950; background:currentColor; mask:var(--wordmark-url) no-repeat center/contain; }
+.hero h1 { margin:0 0 1.25rem; } .hero .lead { max-width:42.5rem; margin:0 auto; color:var(--muted); line-height:1.8; }
+.actions { display:flex; flex-wrap:wrap; gap:0.75rem; align-items:center; }
+.hero .actions { justify-content:center; margin-top:1.75rem; }
+.button { display:inline-flex; align-items:center; justify-content:center; min-height:2.625rem; padding:0.5rem 1rem; border:1px solid var(--border); background:var(--surface); text-decoration:none; font-size:0.875rem; transition:background 150ms ease-out; }
 .button:hover { background:var(--hover); } .button.primary { background:var(--accent); color:var(--brand-ink); border-color:var(--accent); } .button.primary:hover { filter:brightness(1.08); }
-.hero-note { margin:22px 0 0; font-size:12px; color:var(--muted); }
-.section { padding:64px 0; border-top:1px solid var(--subtle); }
-.section-head { display:flex; align-items:end; justify-content:space-between; gap:32px; margin-bottom:28px; }
-.section-head h2 { margin:0 0 12px; } .section-head p { margin:0; color:var(--muted); max-width:640px; }
-.text-link { font-size:13px; text-underline-offset:5px; text-decoration-color:var(--border); white-space:nowrap; } .text-link:hover { text-decoration-color:var(--accent); }
-.split { display:grid; grid-template-columns:1fr 1.45fr; gap:64px; } .split > * { min-width:0; } .split p { color:var(--muted); }
-.principles { margin:0; } .principles>div { padding:20px 0; border-bottom:1px solid var(--subtle); } .principles>div:first-child { padding-top:0; } dt { font-weight:600; } dd { margin:8px 0 0; color:var(--muted); font-size:14px; }
-.split p + .code-frame { margin-top:16px; }
+.hero-note { margin:1.375rem 0 0; font-size:0.75rem; color:var(--muted); }
+.section { padding:4rem 0; border-top:1px solid var(--subtle); }
+.section-head { display:flex; align-items:end; justify-content:space-between; gap:2rem; margin-bottom:1.75rem; }
+.section-head h2 { margin:0 0 0.75rem; } .section-head p { margin:0; color:var(--muted); max-width:40rem; }
+.text-link { font-size:0.8125rem; text-underline-offset:0.3125rem; text-decoration-color:var(--border); white-space:nowrap; } .text-link:hover { text-decoration-color:var(--accent); }
+.split { display:grid; grid-template-columns:1fr 1.45fr; gap:4rem; } .split > * { min-width:0; } .split p { color:var(--muted); }
+.principles { margin:0; } .principles>div { padding:1.25rem 0; border-bottom:1px solid var(--subtle); } .principles>div:first-child { padding-top:0; } dt { font-weight:600; } dd { margin:0.5rem 0 0; color:var(--muted); font-size:0.875rem; }
+.split p + .code-frame { margin-top:1rem; }
 .code-frame { border:1px solid var(--border); min-width:0; background:var(--deep); }
-.code-bar { padding:10px 18px; border-bottom:1px solid var(--border); font-size:12px; display:flex; align-items:center; justify-content:space-between; gap:12px; color:var(--muted); }
-pre { padding:24px; margin:0; overflow:auto; font-size:13px; line-height:1.85; } pre.astro-code { background:transparent!important; } [data-theme='flexoki-light'] pre.astro-code span { color:var(--shiki-light)!important; }
-.catalog { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:36px 40px; } .catalog h3 { padding-bottom:12px; border-bottom:1px solid var(--border); margin:0; }
-.catalog ul { list-style:none; margin:0; padding:0; } .catalog li { border-bottom:1px solid var(--subtle); } .catalog a { display:flex; justify-content:space-between; align-items:center; padding:10px 0; text-decoration:none; font-size:14px; } .catalog a:hover { color:var(--accent); } .catalog a span { font-size:12px; color:var(--muted); }
+.code-bar { padding:0.625rem 1.125rem; border-bottom:1px solid var(--border); font-size:0.75rem; display:flex; align-items:center; justify-content:space-between; gap:0.75rem; color:var(--muted); }
+pre { padding:1.5rem; margin:0; overflow:auto; font-size:0.8125rem; line-height:1.85; } pre.astro-code { background:transparent!important; } [data-theme='flexoki-light'] pre.astro-code span { color:var(--shiki-light)!important; }
+.catalog { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:2.25rem 2.5rem; } .catalog h3 { padding-bottom:0.75rem; border-bottom:1px solid var(--border); margin:0; }
+.catalog ul { list-style:none; margin:0; padding:0; } .catalog li { border-bottom:1px solid var(--subtle); } .catalog a { display:flex; justify-content:space-between; align-items:center; padding:0.625rem 0; text-decoration:none; font-size:0.875rem; } .catalog a:hover { color:var(--accent); } .catalog a span { font-size:0.75rem; color:var(--muted); }
 .gallery-shot { display:block; width:100%; height:auto; border:1px solid var(--border); }
-.site-footer { border-top:1px solid var(--subtle); padding:28px 0; color:var(--muted); font-size:12px; } .site-footer .shell { display:flex; justify-content:space-between; flex-wrap:wrap; gap:16px; }
-.skip-link { position:fixed; left:16px; top:-100px; z-index:500; padding:12px; background:var(--accent); color:var(--brand-ink); } .skip-link:focus { top:12px; }
+.site-footer { border-top:1px solid var(--subtle); padding:1.75rem 0; color:var(--muted); font-size:0.75rem; } .site-footer .shell { display:flex; justify-content:space-between; flex-wrap:wrap; gap:1rem; }
+.skip-link { position:fixed; left:1rem; top:-6.25rem; z-index:500; padding:0.75rem; background:var(--accent); color:var(--brand-ink); } .skip-link:focus { top:0.75rem; }
 [data-theme-changing] *,[data-theme-changing] *::before,[data-theme-changing] *::after { transition:none!important; }
-/* Match src/list.rs: 8px track, 6px square thumb, foreground-tinted states. */
+/* Match src/list.rs: 0.5rem track, 0.375rem square thumb, foreground-tinted states. */
 :root {
   --scrollbar-track:color-mix(in srgb,var(--foreground) 4%,var(--background));
   --scrollbar-thumb:color-mix(in srgb,var(--foreground) 35%,var(--scrollbar-track));
@@ -71,24 +71,24 @@ pre { padding:24px; margin:0; overflow:auto; font-size:13px; line-height:1.85; }
 * { scrollbar-width:thin; scrollbar-color:var(--scrollbar-thumb) var(--scrollbar-track); }
 @supports selector(::-webkit-scrollbar) {
   * { scrollbar-width:auto; scrollbar-color:auto; }
-  ::-webkit-scrollbar { width:8px; height:8px; }
+  ::-webkit-scrollbar { width:0.5rem; height:0.5rem; }
   ::-webkit-scrollbar-track, ::-webkit-scrollbar-corner { background:var(--scrollbar-track); }
   ::-webkit-scrollbar-thumb { border:1px solid var(--scrollbar-track); border-radius:0; background:var(--scrollbar-thumb); background-clip:padding-box; }
   ::-webkit-scrollbar-thumb:hover { background-color:var(--scrollbar-hover); }
   ::-webkit-scrollbar-thumb:active { background-color:var(--scrollbar-active); }
 }
-@media(max-width:760px) { .shell { width:calc(100% - 32px); } .site-nav { gap:14px; } .site-nav .desktop-link { display:none; } .hero { padding:44px 0 36px; } .hero-brand { gap:16px; } .hero-gpui { font-size:13px; } .wordmark { width:210px; } .split { grid-template-columns:1fr; gap:28px; } .section { padding:40px 0; } .section-head { flex-direction:column; align-items:start; gap:12px; } .catalog { grid-template-columns:repeat(2,minmax(0,1fr)); gap:28px 24px; } }
-@media(max-width:420px) { .site-name { font-size:12px; } .site-header .shell { gap:8px; } .site-nav > a { display:none; } .catalog { grid-template-columns:1fr; } .site-nav { gap:8px; } .hero-brand { flex-direction:column; gap:12px; } }
+@media(max-width:47.5rem) { .shell { width:calc(100% - 2rem); } .site-nav { gap:0.875rem; } .site-nav .desktop-link { display:none; } .hero { padding:2.75rem 0 2.25rem; } .hero-brand { gap:1rem; } .hero-gpui { font-size:0.8125rem; } .wordmark { width:13.125rem; } .split { grid-template-columns:1fr; gap:1.75rem; } .section { padding:2.5rem 0; } .section-head { flex-direction:column; align-items:start; gap:0.75rem; } .catalog { grid-template-columns:repeat(2,minmax(0,1fr)); gap:1.75rem 1.5rem; } }
+@media(max-width:26.25rem) { .site-name { font-size:0.75rem; } .site-header .shell { gap:0.5rem; } .site-nav > a { display:none; } .catalog { grid-template-columns:1fr; } .site-nav { gap:0.5rem; } .hero-brand { flex-direction:column; gap:0.75rem; } }
 @media(prefers-reduced-motion:reduce) { html { scroll-behavior:auto; } *,*::before,*::after { transition:none!important; animation:none!important; } }
 
 .hero .text-link { font-size:inherit; }
 .text-link, .principles dt a { color:var(--accent); }
-.principles dt a { text-decoration-color:var(--border); text-underline-offset:4px; }
+.principles dt a { text-decoration-color:var(--border); text-underline-offset:0.25rem; }
 
-.live-gallery { padding-bottom:48px; }
-.live-gallery iframe { display:block; width:100%; height:clamp(320px,calc(100svh - 160px),760px); border:1px solid var(--border); background:var(--background); }
-.gallery-caption { font-size:12px; color:var(--muted); margin:12px 0 0; }
-@media(max-width:760px) { .live-gallery iframe { max-height:620px; } }
+.live-gallery { padding-bottom:3rem; }
+.live-gallery iframe { display:block; width:100%; height:clamp(20rem,calc(100svh - 10rem),47.5rem); border:1px solid var(--border); background:var(--background); }
+.gallery-caption { font-size:0.75rem; color:var(--muted); margin:0.75rem 0 0; }
+@media(max-width:47.5rem) { .live-gallery iframe { max-height:38.75rem; } }
 
-.hero h1.hero-brand { display:block; font-family:"Omarchy Display",monospace; font-size:clamp(30px,6.3vw,76px); font-weight:400; letter-spacing:0; line-height:1.2; margin:0 0 28px; white-space:nowrap; }
-.hero .lead { max-width:860px; }
+.hero h1.hero-brand { display:block; font-family:"Omarchy Display",monospace; font-size:clamp(1.875rem,6.3vw,4.75rem); font-weight:400; letter-spacing:0; line-height:1.2; margin:0 0 1.75rem; white-space:nowrap; }
+.hero .lead { max-width:53.75rem; }

--- a/website/src/styles/guides.css
+++ b/website/src/styles/guides.css
@@ -1,31 +1,31 @@
-.guides-grid { display:grid; grid-template-columns:230px minmax(0,1fr); gap:48px; padding-block:40px 72px; }
-.guide-contents { position:sticky; top:92px; align-self:start; max-height:calc(100svh - 116px); overflow:auto; padding:4px; font-size:13px; }
-.guide-contents summary { cursor:pointer; color:var(--bright); margin-bottom:16px; }
-.guide-contents nav { display:grid; gap:4px; }
-.guide-contents a { display:flex; gap:12px; padding:7px 2px; color:var(--muted); text-decoration:none; }
+.guides-grid { display:grid; grid-template-columns:14.375rem minmax(0,1fr); gap:3rem; padding-block:2.5rem 4.5rem; }
+.guide-contents { position:sticky; top:5.75rem; align-self:start; max-height:calc(100svh - 7.25rem); overflow:auto; padding:0.25rem; font-size:0.8125rem; }
+.guide-contents summary { cursor:pointer; color:var(--bright); margin-bottom:1rem; }
+.guide-contents nav { display:grid; gap:0.25rem; }
+.guide-contents a { display:flex; gap:0.75rem; padding:0.4375rem 0.125rem; color:var(--muted); text-decoration:none; }
 .guide-contents a:hover,.guide-contents a:focus-visible { color:var(--bright); }
 .guide-contents a span { font-variant-numeric:tabular-nums; }
 .guide-prose { min-width:0; max-width:48rem; overflow-wrap:anywhere; color:var(--foreground); }
-.guide-download { display:inline-block; margin-bottom:20px; font-size:13px; }
-.guide-prose h1 { margin-top:0; font-size:28px; }
-.guide-prose h2 { margin:56px 0 20px; padding-top:24px; border-top:1px solid var(--subtle); font-size:22px; }
-.guide-prose h3 { margin:32px 0 14px; font-size:18px; }
-.guide-prose h4 { font-size:16px; }
+.guide-download { display:inline-block; margin-bottom:1.25rem; font-size:0.8125rem; }
+.guide-prose h1 { margin-top:0; font-size:1.75rem; }
+.guide-prose h2 { margin:3.5rem 0 1.25rem; padding-top:1.5rem; border-top:1px solid var(--subtle); font-size:1.375rem; }
+.guide-prose h3 { margin:2rem 0 0.875rem; font-size:1.125rem; }
+.guide-prose h4 { font-size:1rem; }
 .guide-prose h1,.guide-prose h2,.guide-prose h3 { color:var(--bright); letter-spacing:-.01em; }
-.guide-prose p { margin:16px 0; }
-.guide-prose a,.guides-page .site-footer a { color:inherit; text-decoration-color:var(--border); text-underline-offset:3px; }
+.guide-prose p { margin:1rem 0; }
+.guide-prose a,.guides-page .site-footer a { color:inherit; text-decoration-color:var(--border); text-underline-offset:0.1875rem; }
 .guide-prose a:hover,.guides-page .site-footer a:hover { text-decoration-color:var(--accent); }
-.guide-prose ul { list-style:square; padding-left:24px; }
-.guide-prose ol { list-style:decimal; padding-left:24px; }
-.guide-prose li { margin-block:6px; }
+.guide-prose ul { list-style:square; padding-left:1.5rem; }
+.guide-prose ol { list-style:decimal; padding-left:1.5rem; }
+.guide-prose li { margin-block:0.375rem; }
 .guide-prose li::marker { color:var(--muted); }
 .guide-prose :not(pre)>code { background:var(--hover); padding:.15em .4em; font-size:.86em; }
-.guide-prose pre { margin:20px 0; padding:18px 20px; border:1px solid var(--subtle); background:var(--deep)!important; max-width:100%; overflow-wrap:normal; }
-.guide-prose table { display:block; width:100%; overflow-x:auto; border-collapse:collapse; font-size:13px; margin:20px 0; }
-.guide-prose th,.guide-prose td { padding:10px 12px; border:1px solid var(--subtle); text-align:left; vertical-align:top; min-width:140px; }
+.guide-prose pre { margin:1.25rem 0; padding:1.125rem 1.25rem; border:1px solid var(--subtle); background:var(--deep)!important; max-width:100%; overflow-wrap:normal; }
+.guide-prose table { display:block; width:100%; overflow-x:auto; border-collapse:collapse; font-size:0.8125rem; margin:1.25rem 0; }
+.guide-prose th,.guide-prose td { padding:0.625rem 0.75rem; border:1px solid var(--subtle); text-align:left; vertical-align:top; min-width:8.75rem; }
 .guide-prose th { color:var(--bright); background:var(--surface); }
-.guide-prose blockquote { margin:20px 0; padding:1px 18px; border-left:2px solid var(--accent); color:var(--muted); }
+.guide-prose blockquote { margin:1.25rem 0; padding:0.0625rem 1.125rem; border-left:2px solid var(--accent); color:var(--muted); }
 .guides-page .site-nav a[aria-current] { display:inline; color:var(--bright); }
-@media(max-width:900px) { .guides-grid { grid-template-columns:190px minmax(0,1fr); gap:24px; } }
-@media(max-width:760px) { .guides-grid { grid-template-columns:minmax(0,1fr); padding-top:24px; } .guide-contents { position:static; max-height:none; border-bottom:1px solid var(--subtle); padding-bottom:16px; } .guide-contents nav { grid-template-columns:repeat(2,minmax(0,1fr)); } .guide-prose h2 { margin-top:40px; } }
-@media(max-width:420px) { .guide-contents nav { grid-template-columns:1fr; } }
+@media(max-width:56.25rem) { .guides-grid { grid-template-columns:11.875rem minmax(0,1fr); gap:1.5rem; } }
+@media(max-width:47.5rem) { .guides-grid { grid-template-columns:minmax(0,1fr); padding-top:1.5rem; } .guide-contents { position:static; max-height:none; border-bottom:1px solid var(--subtle); padding-bottom:1rem; } .guide-contents nav { grid-template-columns:repeat(2,minmax(0,1fr)); } .guide-prose h2 { margin-top:2.5rem; } }
+@media(max-width:26.25rem) { .guide-contents nav { grid-template-columns:1fr; } }


### PR DESCRIPTION
## Summary

Fixed pixel dimensions prevented controls from scaling with the window's rem size. Move component, gallery and website dimensions to rem, resolve pixel-only APIs against the current window, and remeasure virtual rows when zoom changes. Add gallery zoom controls from 50% to 200%, reset, and Cmd/Ctrl shortcuts that also work while editing.

- Render tabs and form choices as segmented controls, with the active border tied to selection and optional shortcut number hints.
- Add Input prefix/suffix slots without changing the editable value.
- Update examples and documentation. Keep physical borders, native window bounds and the base theme's nominal pixel snapshot explicit.

API changes: `tab_list` adds `show_shortcuts` after the selected index; `input` returns the new `Input` wrapper; `scrollbar`, `markdown`, `html` and `text_view_style` take `window: &Window` before `cx`.

## Test Plan

- `cargo test --all-targets` — 69 passed, including both themes at three rem sizes, input affixes, list remeasurement, zoom limits/reset and shortcuts while editing.
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check` and `git diff --check`
- `cargo +nightly check --locked --manifest-path examples/gallery-wasm/Cargo.toml --target wasm32-unknown-unknown`
- `cd website && bun run build` — Astro checks/build and 5 website tests passed.
