### PR TITLE
fix: watch system theme files instead of polling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2343,8 +2343,10 @@ dependencies = [
 name = "gpui-omarchy"
 version = "0.1.2"
 dependencies = [
+ "async-channel",
  "chrono",
  "gpui-kit",
+ "notify",
  "tempfile",
  "toml 0.8.23",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ gpui-kit = { version = "=0.6.1", default-features = false, features = ["assets"]
 toml = "0.8"
 chrono = "0.4.45"
 
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+async-channel = "2"
+notify = "7"
+
 [dev-dependencies]
 tempfile = "3"
 gpui-kit = { version = "=0.6.1", default-features = false, features = ["test-support"] }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Both ANSI `color0..15` and semantic Omarchy color formats are supported. Missing
 
 Theme locations and the theme-name file follow the [Omarchy theme-set script](https://github.com/basecamp/omarchy/blob/master/bin/omarchy-theme-set). See the [ANSI theme](https://github.com/basecamp/omarchy/blob/master/themes/tokyo-night/colors.toml) and [semantic theme](https://github.com/basecamp/omarchy/blob/quattro/themes/tokyo-night/colors.toml) for color formats.
 
-Native applications follow the system theme after `init`: a background check every second detects palette edits and theme symlink replacements, then updates all windows only when the theme changes. Applying an explicit theme with `Theme::apply(cx)` stops following; `Theme::follow_system(cx)` resumes it. `Theme::system_or_default()` remains a one-time snapshot. Browsers use the default palette without filesystem monitoring. `shell.toml` size and state overrides are not yet implemented. Flexoki Light is available for previewing light colors; the gallery follows the system theme by default.
+Native applications follow the system theme after `init`: filesystem events detect palette edits and theme symlink replacements, and all windows update only when the theme changes. Applying an explicit theme with `Theme::apply(cx)` stops following; `Theme::follow_system(cx)` resumes it. `Theme::system_or_default()` remains a one-time snapshot. `Theme::follow_system(cx)` does nothing in browsers; initialization still supplies the default palette. `shell.toml` size and state overrides are not yet implemented. Flexoki Light is available for previewing light colors; the gallery follows the system theme by default.
 
 ## Usage
 

--- a/examples/gallery-wasm/Cargo.lock
+++ b/examples/gallery-wasm/Cargo.lock
@@ -1668,6 +1668,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,6 +1843,15 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2188,8 +2207,10 @@ dependencies = [
 name = "gpui-omarchy"
 version = "0.1.2"
 dependencies = [
+ "async-channel",
  "chrono",
  "gpui-kit",
+ "notify",
  "toml 0.8.23",
 ]
 
@@ -3169,6 +3190,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3337,6 +3378,26 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kqueue"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+]
 
 [[package]]
 name = "kurbo"
@@ -3741,6 +3802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -3859,6 +3921,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.13.1",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "notify-rust"
 version = "4.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3870,6 +3951,15 @@ dependencies = [
  "serde",
  "tauri-winrt-notification",
  "zbus",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
 ]
 
 [[package]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,5 +73,8 @@ pub fn init(cx: &mut gpui_kit::App) {
     button_group::init(cx);
     popover::init(cx);
     date_picker::init(cx);
+    #[cfg(not(target_family = "wasm"))]
     Theme::follow_system(cx);
+    #[cfg(target_family = "wasm")]
+    Theme::tokyo_night().apply(cx);
 }

--- a/src/system_theme.rs
+++ b/src/system_theme.rs
@@ -4,6 +4,9 @@ use gpui_kit::base::ThemeAppearance;
 use gpui_kit::{Hsla, Rgba, rgb};
 use std::{fmt, fs, path::Path};
 
+#[cfg(not(target_family = "wasm"))]
+mod watch;
+
 #[derive(Debug)]
 pub struct ThemeLoadError(String);
 impl fmt::Display for ThemeLoadError {
@@ -31,29 +34,45 @@ pub(crate) fn stop_following(cx: &mut gpui_kit::App) {
 
 impl Theme {
     /// Apply the system palette and follow changes until an explicit theme is applied.
-    /// Native apps check once per second off the UI thread, following replaced symlinks.
-    /// Browsers use the default palette without filesystem monitoring.
+    /// Native apps reload on filesystem events off the UI thread, following replaced symlinks.
+    /// Does nothing in browsers, where the Omarchy filesystem is unavailable.
     pub fn follow_system(cx: &mut gpui_kit::App) {
         #[cfg(not(target_family = "wasm"))]
         Self::follow_system_from_home(std::env::var_os("HOME").map(Into::into), cx);
         #[cfg(target_family = "wasm")]
-        Self::tokyo_night().apply(cx);
+        let _ = cx;
     }
 
     #[cfg(not(target_family = "wasm"))]
     fn follow_system_from_home(home: Option<std::path::PathBuf>, cx: &mut gpui_kit::App) {
-        let mut previous = Self::system_from_home(home.as_deref());
+        stop_following(cx);
+        let Some(home) = home.filter(|home| !home.as_os_str().is_empty()) else {
+            Self::tokyo_night().apply(cx);
+            return;
+        };
+        // Register before reading so a change during startup is not missed.
+        let watcher = watch::PaletteWatcher::new(&home);
+        let mut previous = Self::system_from_home(Some(&home));
         previous.clone().apply(cx);
+        let (mut watcher, events) = match watcher {
+            Ok(watcher) => watcher,
+            Err(error) => {
+                eprintln!("Cannot watch Omarchy theme: {error}");
+                return;
+            }
+        };
         let task = cx.spawn(async move |cx| {
-            loop {
-                cx.background_executor()
-                    .timer(std::time::Duration::from_secs(1))
-                    .await;
+            while events.recv().await.is_ok() {
                 let home = home.clone();
-                let theme = cx
+                let (next_watcher, theme) = cx
                     .background_executor()
-                    .spawn(async move { Self::system_from_home(home.as_deref()) })
+                    .spawn(async move {
+                        watcher.refresh(&home);
+                        let theme = Self::system_from_home(Some(&home));
+                        (watcher, theme)
+                    })
                     .await;
+                watcher = next_watcher;
                 if theme != previous {
                     previous = theme.clone();
                     cx.update(|cx| theme.apply_palette(cx));
@@ -214,15 +233,34 @@ fn contrast(a: Hsla, b: Hsla) -> f32 {
 mod tests {
     use super::*;
     const ANSI: &str = "background = '#fffcf0'\nforeground = '#100f0f'\naccent = '#205ea6'\ncolor1 = '#af3029'\ncolor2 = '#526600'\ncolor3 = '#855b00'\n";
+    #[cfg(not(target_family = "wasm"))]
+    fn wait_for_theme(cx: &mut gpui_kit::TestAppContext, expected: impl Fn(&Theme) -> bool) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            cx.run_until_parked();
+            if cx.update(|cx| expected(cx.global::<Theme>())) {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "filesystem event did not update theme"
+            );
+            // Native watcher callbacks use real time; leave GPUI's timer clock frozen.
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
     #[cfg(unix)]
     #[gpui_kit::test]
     fn following_system_tracks_symlink_replacement_edits_and_recovery(
         cx: &mut gpui_kit::TestAppContext,
     ) {
+        cx.background_executor.allow_parking();
         let home = tempfile::tempdir().unwrap();
         let current = home.path().join(".local/state/omarchy/current");
         let first = home.path().join("first");
-        let second = home.path().join("second");
+        let external = tempfile::tempdir().unwrap();
+        let second = external.path().join("second");
         fs::create_dir_all(&current).unwrap();
         for path in [&first, &second] {
             fs::create_dir_all(path).unwrap();
@@ -241,22 +279,14 @@ mod tests {
         .unwrap();
         std::os::unix::fs::symlink(&second, current.join("next")).unwrap();
         fs::rename(current.join("next"), current.join("theme")).unwrap();
-        cx.dispatcher
-            .advance_clock(std::time::Duration::from_secs(1));
-        cx.run_until_parked();
-        cx.update(|cx| assert_eq!(cx.global::<Theme>().accent, Hsla::from(rgb(0x7aa2f7))));
+        wait_for_theme(cx, |theme| theme.accent == Hsla::from(rgb(0x7aa2f7)));
 
         fs::write(second.join("colors.toml"), "broken").unwrap();
-        cx.dispatcher
-            .advance_clock(std::time::Duration::from_secs(1));
-        cx.run_until_parked();
-        cx.update(|cx| assert_eq!(cx.global::<Theme>().name.as_ref(), "Tokyo Night"));
+        wait_for_theme(cx, |theme| theme.name.as_ref() == "Tokyo Night");
 
         fs::write(second.join("colors.toml"), ANSI).unwrap();
         fs::write(current.join("theme.name"), "Recovered").unwrap();
-        cx.dispatcher
-            .advance_clock(std::time::Duration::from_secs(1));
-        cx.run_until_parked();
+        wait_for_theme(cx, |theme| theme.name.as_ref() == "Recovered");
         cx.update(|cx| {
             assert_eq!(cx.global::<Theme>().name.as_ref(), "Recovered");
             assert_eq!(cx.global::<Theme>().accent, Hsla::from(rgb(0x205ea6)));
@@ -264,7 +294,121 @@ mod tests {
                 gpui_kit::base::Theme::global(cx).tokens.colors.primary,
                 Hsla::from(rgb(0x205ea6))
             );
+            stop_following(cx);
         });
+    }
+
+    #[cfg(unix)]
+    #[gpui_kit::test]
+    fn following_system_tracks_external_palette_and_name_files(cx: &mut gpui_kit::TestAppContext) {
+        cx.background_executor.allow_parking();
+        for location in [".local/state/omarchy/current", ".config/omarchy/current"] {
+            let home = tempfile::tempdir().unwrap();
+            let palette_dir = tempfile::tempdir().unwrap();
+            let name_dir = tempfile::tempdir().unwrap();
+            let current = home.path().join(location);
+            let palette = palette_dir.path().join("palette.toml");
+            let name = name_dir.path().join("name");
+            fs::create_dir_all(current.join("theme")).unwrap();
+            fs::write(&palette, ANSI).unwrap();
+            fs::write(&name, "External").unwrap();
+            std::os::unix::fs::symlink(&palette, current.join("theme/colors.toml")).unwrap();
+            std::os::unix::fs::symlink(&name, current.join("theme.name")).unwrap();
+            cx.update(|cx| {
+                gpui_kit::base::init(cx);
+                Theme::follow_system_from_home(Some(home.path().into()), cx);
+                assert_eq!(cx.global::<Theme>().name.as_ref(), "External");
+            });
+            cx.run_until_parked();
+
+            fs::write(&palette, ANSI.replace("#205ea6", "#123456")).unwrap();
+            wait_for_theme(cx, |theme| theme.accent == Hsla::from(rgb(0x123456)));
+            fs::write(&name, "Edited").unwrap();
+            wait_for_theme(cx, |theme| theme.name.as_ref() == "Edited");
+
+            let replacement = palette_dir.path().join("replacement.toml");
+            fs::write(&replacement, ANSI).unwrap();
+            fs::rename(replacement, &palette).unwrap();
+            wait_for_theme(cx, |theme| theme.accent == Hsla::from(rgb(0x205ea6)));
+            let replacement = name_dir.path().join("replacement");
+            fs::write(&replacement, "Replaced").unwrap();
+            fs::rename(replacement, &name).unwrap();
+            wait_for_theme(cx, |theme| theme.name.as_ref() == "Replaced");
+
+            // Retarget to a missing file in a missing directory, then recover.
+            let future = tempfile::tempdir().unwrap();
+            let target = future.path().join("later/palette.toml");
+            std::os::unix::fs::symlink(&target, current.join("theme/next")).unwrap();
+            fs::rename(
+                current.join("theme/next"),
+                current.join("theme/colors.toml"),
+            )
+            .unwrap();
+            wait_for_theme(cx, |theme| theme.name.as_ref() == "Tokyo Night");
+            fs::create_dir_all(target.parent().unwrap()).unwrap();
+            fs::write(&target, ANSI).unwrap();
+            wait_for_theme(cx, |theme| theme.name.as_ref() == "Replaced");
+            fs::write(&target, ANSI.replace("#205ea6", "#654321")).unwrap();
+            wait_for_theme(cx, |theme| theme.accent == Hsla::from(rgb(0x654321)));
+
+            fs::remove_file(&name).unwrap();
+            wait_for_theme(cx, |theme| theme.name.as_ref() == "Omarchy");
+            fs::write(&name, "Recovered").unwrap();
+            wait_for_theme(cx, |theme| theme.name.as_ref() == "Recovered");
+            cx.update(stop_following);
+        }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[gpui_kit::test]
+    fn following_system_handles_creation_atomic_saves_and_directory_recreation(
+        cx: &mut gpui_kit::TestAppContext,
+    ) {
+        cx.background_executor.allow_parking();
+        let home = tempfile::tempdir().unwrap();
+        cx.update(|cx| {
+            gpui_kit::base::init(cx);
+            Theme::follow_system_from_home(Some(home.path().into()), cx);
+            assert_eq!(cx.global::<Theme>().name.as_ref(), "Tokyo Night");
+        });
+        cx.run_until_parked();
+        let legacy = home.path().join(".config/omarchy/current");
+        fs::create_dir_all(legacy.join("theme")).unwrap();
+        fs::write(legacy.join("theme/colors.toml"), ANSI).unwrap();
+        fs::write(legacy.join("theme.name"), "Legacy").unwrap();
+        wait_for_theme(cx, |theme| theme.name.as_ref() == "Legacy");
+
+        let current = home.path().join(".local/state/omarchy/current");
+        fs::create_dir_all(current.join("theme")).unwrap();
+        fs::write(current.join("theme/colors.toml"), ANSI).unwrap();
+        fs::write(current.join("theme.name"), "Current").unwrap();
+        wait_for_theme(cx, |theme| theme.name.as_ref() == "Current");
+
+        fs::write(
+            current.join("theme/next.toml"),
+            ANSI.replace("#205ea6", "#123456"),
+        )
+        .unwrap();
+        fs::rename(
+            current.join("theme/next.toml"),
+            current.join("theme/colors.toml"),
+        )
+        .unwrap();
+        wait_for_theme(cx, |theme| theme.accent == Hsla::from(rgb(0x123456)));
+
+        fs::remove_dir_all(&current).unwrap();
+        wait_for_theme(cx, |theme| theme.name.as_ref() == "Legacy");
+        fs::create_dir_all(current.join("theme")).unwrap();
+        fs::write(current.join("theme/colors.toml"), ANSI).unwrap();
+        fs::write(current.join("theme.name"), "Recreated").unwrap();
+        wait_for_theme(cx, |theme| theme.name.as_ref() == "Recreated");
+        fs::write(
+            current.join("theme/colors.toml"),
+            ANSI.replace("#205ea6", "#654321"),
+        )
+        .unwrap();
+        wait_for_theme(cx, |theme| theme.accent == Hsla::from(rgb(0x654321)));
+        cx.update(stop_following);
     }
 
     #[cfg(not(target_family = "wasm"))]
@@ -272,6 +416,7 @@ mod tests {
     fn explicit_theme_stops_following_and_system_can_be_selected_again(
         cx: &mut gpui_kit::TestAppContext,
     ) {
+        cx.background_executor.allow_parking();
         let home = tempfile::tempdir().unwrap();
         let current = home.path().join(".local/state/omarchy/current/theme");
         fs::create_dir_all(&current).unwrap();
@@ -281,7 +426,10 @@ mod tests {
             Theme::follow_system_from_home(Some(home.path().into()), cx);
         });
         cx.run_until_parked();
-        cx.update(|cx| Theme::tokyo_night().apply(cx));
+        cx.update(|cx| {
+            Theme::tokyo_night().apply(cx);
+            assert!(cx.try_global::<SystemThemeWatcher>().is_none());
+        });
         fs::write(
             current.join("colors.toml"),
             ANSI.replace("#205ea6", "#ffffff"),
@@ -295,6 +443,9 @@ mod tests {
             Theme::follow_system_from_home(Some(home.path().into()), cx);
             assert_eq!(cx.global::<Theme>().accent, Hsla::from(rgb(0xffffff)));
         });
+        fs::write(current.join("colors.toml"), ANSI).unwrap();
+        wait_for_theme(cx, |theme| theme.accent == Hsla::from(rgb(0x205ea6)));
+        cx.update(stop_following);
     }
 
     #[test]

--- a/src/system_theme/watch.rs
+++ b/src/system_theme/watch.rs
@@ -1,0 +1,114 @@
+//! Watch directories rather than files so atomic saves and symlink swaps survive.
+use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+pub(super) struct PaletteWatcher {
+    watcher: RecommendedWatcher,
+    paths: BTreeMap<PathBuf, Identity>,
+}
+
+// A deleted directory can be recreated at the same path before events are read.
+// Its old OS watch then refers to a different inode and must be replaced.
+#[cfg(unix)]
+type Identity = (u64, u64);
+#[cfg(not(unix))]
+type Identity = Option<std::time::SystemTime>;
+
+fn identity(metadata: &fs::Metadata) -> Identity {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        (metadata.dev(), metadata.ino())
+    }
+    #[cfg(not(unix))]
+    metadata.created().ok()
+}
+
+impl PaletteWatcher {
+    pub(super) fn new(home: &Path) -> notify::Result<(Self, async_channel::Receiver<()>)> {
+        // Coalesce bursts without blocking the OS callback or growing a queue.
+        let (sender, receiver) = async_channel::bounded(1);
+        let watcher = notify::recommended_watcher(move |event: notify::Result<notify::Event>| {
+            // Reading the palette must not trigger another reload on Linux.
+            if !matches!(&event, Ok(event) if event.kind.is_access()) {
+                if let Err(error) = event {
+                    eprintln!("Omarchy theme watcher error: {error}");
+                }
+                let _ = sender.try_send(());
+            }
+        })?;
+        let mut watcher = Self {
+            watcher,
+            paths: BTreeMap::new(),
+        };
+        watcher.refresh(home);
+        Ok((watcher, receiver))
+    }
+
+    pub(super) fn refresh(&mut self, home: &Path) {
+        let mut desired = BTreeMap::new();
+        // Start at both consumed files so file symlinks are followed too;
+        // retaining their lexical ancestors also catches link replacement.
+        for relative in [
+            ".local/state/omarchy/current/theme/colors.toml",
+            ".local/state/omarchy/current/theme.name",
+            ".config/omarchy/current/theme/colors.toml",
+            ".config/omarchy/current/theme.name",
+        ] {
+            let path = home.join(relative);
+            for ancestor in path.ancestors() {
+                add_directory(ancestor, &mut desired);
+                // Also watch a dangling link's target parents for later creation.
+                if let Ok(target) = fs::read_link(ancestor) {
+                    let target = ancestor.parent().unwrap_or(home).join(target);
+                    for parent in target.ancestors() {
+                        if parent.is_dir() {
+                            add_directory(parent, &mut desired);
+                            if let Some(grandparent) = parent.parent() {
+                                add_directory(grandparent, &mut desired);
+                            }
+                            break;
+                        }
+                    }
+                }
+                if ancestor == home {
+                    break;
+                }
+            }
+        }
+        self.paths.retain(|path, old| {
+            if desired.get(path) == Some(old) {
+                true
+            } else {
+                let _ = self.watcher.unwatch(path);
+                false
+            }
+        });
+        for (path, identity) in desired {
+            if !self.paths.contains_key(&path) {
+                match self.watcher.watch(&path, RecursiveMode::NonRecursive) {
+                    Ok(()) => {
+                        self.paths.insert(path, identity);
+                    }
+                    Err(error) => {
+                        eprintln!("Cannot watch Omarchy path {}: {error}", path.display())
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn add_directory(path: &Path, paths: &mut BTreeMap<PathBuf, Identity>) {
+    if let Ok(path) = fs::canonicalize(path) {
+        if let Ok(metadata) = fs::metadata(&path) {
+            if metadata.is_dir() {
+                paths.insert(path, identity(&metadata));
+            }
+        }
+    }
+}

--- a/website/src/pages/guides.md
+++ b/website/src/pages/guides.md
@@ -201,7 +201,7 @@ $HOME/.local/state/omarchy/current/theme/colors.toml
 $HOME/.local/state/omarchy/current/theme.name
 ```
 
-It checks for changes once per second off the UI thread, including replaced theme symlinks. The legacy `$HOME/.config/omarchy/current` location is used only when the current state directory is absent. An existing but invalid current theme falls back to Tokyo Night rather than reviving a stale legacy theme.
+It watches filesystem changes and reloads off the UI thread, including replaced theme symlinks and edits to their targets. The legacy `$HOME/.config/omarchy/current` location is used only when the current state directory is absent. An existing but invalid current theme falls back to Tokyo Night rather than reviving a stale legacy theme.
 
 For an application theme switcher, apply a palette explicitly:
 
@@ -229,7 +229,7 @@ Import `ActiveTheme` to use `omarchy(&self) -> &Theme` on `App` and through cont
 | `Theme::tokyo_night() -> Theme` | Construct the default dark palette without applying it. |
 | `Theme::flexoki_light() -> Theme` | Construct the built-in warm light palette. |
 | `Theme::system_or_default() -> Theme` | Read a one-time system snapshot, with atomic Tokyo Night fallback. This does not start watching. |
-| `Theme::follow_system(&mut App)` | Apply the system palette and follow later changes. In browsers, apply Tokyo Night without filesystem monitoring. |
+| `Theme::follow_system(&mut App)` | Apply the system palette and follow later changes. Does nothing in browsers. |
 | `Theme::from_current_dir(path: impl AsRef<Path>) -> Result<Theme, ThemeLoadError>` | Read `theme/colors.toml` under a supplied current directory, with optional `theme.name`. |
 | `Theme::from_colors_toml(name: &str, contents: &str) -> Result<Theme, ThemeLoadError>` | Parse palette text already loaded by your application. |
 


### PR DESCRIPTION
Closes #1 

## Summary

Replace once-per-second system theme polling with native filesystem notifications. Palette edits, atomic saves, directory recreation, and directory/file symlink changes reload the theme off the UI thread. Explicit theme selection releases the watcher; legacy path precedence and invalid-palette fallback are preserved.

Make `Theme::follow_system` a no-op on WebAssembly while keeping default palette initialization in `init`. Add regression coverage for external `colors.toml` and `theme.name` symlink targets, including replacement and recovery, and update the documentation.

## Test Plan

- `cargo test --locked --all-targets` — 73 tests passed on macOS.
- `cargo +nightly check --locked --manifest-path examples/gallery-wasm/Cargo.toml --target wasm32-unknown-unknown` — passed.
- `cargo fmt --all -- --check` and `git diff --check` — passed.
- Confirmed the file-symlink regression test failed before the fix and passed afterward. Native filesystem behavior has not been run on Linux or Windows.
